### PR TITLE
Add configurable date and time to output of `status` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,23 @@ be recorded.
 
 ### status
 
-Display the time spent since the current project was started.
+Display when the current project was started and the time spent since.
+
+You can configure how the date and time of when the project was started are
+displayed by setting `options.date_format` and `options.time_format` in the
+configuration. The syntax of these formatting strings and the supported
+placeholders are the same as for the `strftime` method of Python's
+[datetime.datetime][datetime] class.
+
+[datetime]: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
 
 ```
 $ watson status
-Project apollo11 started seconds ago
+Project apollo11 [brakes] started seconds ago (2014-05-19 14:32:41+0100)
+$ watson config options.date_format %d.%m.%Y
+$ watson config options.time_format "at %I:%M %p"
+$ watson status
+Project apollo11 [brakes] started a minute ago (19.05.2014 at 02:32 PM)
 ```
 
 ### report

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -183,22 +183,38 @@ def cancel(watson):
 @click.pass_obj
 def status(watson):
     """
-    Display the time spent since the current project was started.
+    Display when the current project was started and the time spent since.
+
+    You can configure how the date and time of when the project was started are
+    displayed by setting 'options.date_format' and 'options.time_format' in the
+    configuration. The syntax of these formatting strings and the supported
+    placeholders are the same as for the 'strftime' method of Python's
+    'datetime.datetime' class.
 
     \b
     Example:
     $ watson status
-    Project apollo11 started seconds ago
+    Project apollo11 [brakes] started seconds ago (2014-05-19 14:32:41+0100)
+    $ watson config options.date_format %d.%m.%Y
+    $ watson config options.time_format "at %I:%M %p"
+    $ watson status
+    Project apollo11 [brakes] started a minute ago (19.05.2014 at 02:32 PM)
     """
     if not watson.is_started:
         click.echo("No project started")
         return
 
     current = watson.current
-    click.echo("Project {} {} started {}".format(
+    options = (dict(watson.config.items('options'))
+               if watson.config.has_section('options') else {})
+    datefmt = options.get('date_format', '%Y.%m.%d')
+    timefmt = options.get('time_format', '%H:%M:%S%z')
+    click.echo("Project {} {} started {} ({} {})".format(
         style('project', current['project']),
         style('tags', current['tags']),
-        style('time', current['start'].humanize())
+        style('time', current['start'].humanize()),
+        style('date', current['start'].strftime(datefmt)),
+        style('time', current['start'].strftime(timefmt))
     ))
 
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -5,10 +5,10 @@ import json
 
 try:
     import configparser
-    from configparser import ConfigParser
+    from configparser import RawConfigParser as ConfigParser
 except ImportError:
     import ConfigParser as configparser  # noqa
-    from ConfigParser import SafeConfigParser as ConfigParser  # noqa
+    from ConfigParser import RawConfigParser as ConfigParser  # noqa
 
 import arrow
 import click


### PR DESCRIPTION
Fixes #33. See also the discussion there.

In this version I uses `Arrow.strftime()` to format the date and time, so arbitrary additional fixed strings can be included, e.g. `Am %d.%m.%Y um %H:%M Uhr`.

Since `SafeConfigParser` (resp. `ConfigParser` in Python 3) uses the percent sign for interpolation too and I don't think this feature is needed, I included a change to the import of the modul so that the version without interpolation is used. With this change you don't have to use two percent signs for the date/time placeholders in the config file.