### PR TITLE
Add configuration for Bash command line completion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.md
 include LICENCE
 include tox.ini
 include requirements.txt
+include watson.completion
 recursive-include requirements *
 recursive-include tests *
 recursive-include scripts *

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ $ cd Watson/
 $ python setup.py install
 ```
 
+### Command line completion
+
+If you use a Bash-compatible shell, you can install the `watson.completion`
+file from the source distribution as `/etc/bash.completion.d/watson` - or
+wherever your distribution keeps the Bash completion configuration files.
+After you restart your shell, you can then just type `watson` on your command
+line and then hit TAB to see all available commands. Depending on your input,
+it completes watson commands, command options, projects, tags and frame IDs.
+
 ## Commands
 
 Here is the listing of all the commands available with Watson. You can also
@@ -188,6 +197,19 @@ Thursday 17 April 2014
 Wednesday 16 April 2014
         02cb269  09:53 to 12:43  2h 50m 07s  apollo11  [wheels]
         1070ddb  13:48 to 16:17  2h 29m 11s  voyager1  [antenna, sensors]
+```
+
+### frames
+Display the list of all frame IDs.
+
+This is mainly useful for implementing Bash command line completion.
+
+```
+$ watson frames
+f1c4815
+9d1a989
+8801ec3
+[...]
 ```
 
 ### projects

--- a/watson.completion
+++ b/watson.completion
@@ -1,0 +1,66 @@
+# Bash completion support for watson
+#
+# Install this as `/etc/bash_completion.d/watson` and restart your shell.
+
+_watson_complete () {
+  local cur cmd commands frames projects tags
+
+  commands='cancel config edit frames help log projects remove report start status stop sync tags'
+
+  cur=${COMP_WORDS[COMP_CWORD]}
+  cmd=${COMP_WORDS[1]}
+
+  case ${COMP_CWORD} in
+    1)
+      COMPREPLY=($(compgen -W "$commands" -- "$cur" )) ;;
+    *)
+      case "${cmd}" in
+        config)
+          COMPREPLY=($(compgen -W "-e --edit" -- ${cur})) ;;
+        edit)
+          frames="$(watson frames)"
+          COMPREPLY=($(compgen -W "$frames" -- ${cur}))
+          ;;
+        help)
+          COMPREPLY=($(compgen -W "$commands" -- "$cur" )) ;;
+        log|report)
+          case "$3" in
+            -p|--project)
+              projects="$(watson projects)"
+              COMPREPLY=($(compgen -W "$projects" -- ${cur}))
+              ;;
+            -T|--tag)
+              tags="$(watson tags)"
+              COMPREPLY=($(compgen -W "$tags" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "-f -t -p -T --from --to --project --tag" -- ${cur})) ;;
+          esac
+          ;;
+        remove)
+          case "${cur}" in
+            -*)
+              COMPREPLY=($(compgen -W "-f --force" -- ${cur})) ;;
+            *)
+              frames="$(watson frames)"
+              COMPREPLY=($(compgen -W "$frames" -- ${cur}))
+              ;;
+          esac
+          ;;
+        start)
+          if [[ $COMP_CWORD -eq 2 ]]; then
+            projects="$(watson projects)"
+            COMPREPLY=($(compgen -W "$projects" -- ${cur}))
+          else
+            tags="$(watson tags | awk '$0="+"$0')"
+            COMPREPLY=($(compgen -W "$tags" -- ${cur}))
+          fi
+          ;;
+      esac
+      ;;
+  esac
+
+  return 0
+}
+
+complete -F _watson_complete watson

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -487,6 +487,24 @@ def tags(watson):
 
 
 @cli.command()
+@click.pass_obj
+def frames(watson):
+    """
+    Display the list of all frame IDs.
+
+    \b
+    Example:
+    $ watson frames
+    f1c4815
+    9d1a989
+    8801ec3
+    [...]
+    """
+    for frame in watson.frames:
+        click.echo(style('short_id', frame.id))
+
+
+@cli.command()
 @click.argument('id', required=False)
 @click.pass_obj
 def edit(watson, id):


### PR DESCRIPTION
Fixes #1 

I've also added a new command `frames` to list all frame IDs to support completion for the `edit` and `remove` commands. I've put this into an extra commit, so you can choose to include it or not.

Also added some documentation for it in the readme.