### PR TITLE
Keep cjk characters unescaped.

### DIFF
--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -353,6 +353,9 @@ def test_save_current_without_tags(watson):
             assert isinstance(result['start'], (int, float))
             assert result['tags'] == []
 
+            dump_args = json_mock.call_args[1]
+            assert dump_args['ensure_ascii'] is False
+
 
 def test_save_empty_current(config_dir):
     watson = Watson(current={'project': 'foo', 'start': 0},
@@ -410,6 +413,9 @@ def test_save_changed_frame(config_dir):
             assert len(result) == 1
             assert result[0][2] == 'bar'
             assert result[0][4] == ['A', 'B']
+
+            dump_args = json_mock.call_args[1]
+            assert dump_args['ensure_ascii'] is False
 
 
 def test_save_config_no_changes(watson):

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -517,7 +517,7 @@ def edit(watson, id):
         'stop': frame.stop.format(format),
         'project': frame.project,
         'tags': frame.tags,
-    }, indent=4, sort_keys=True)
+    }, indent=4, sort_keys=True, ensure_ascii=False)
 
     output = click.edit(text, extension='.json')
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -141,11 +141,12 @@ class Watson(object):
                     current = {}
 
                 with open(self.state_file, 'w+') as f:
-                    json.dump(current, f, indent=1)
+                    json.dump(current, f, indent=1, ensure_ascii=False)
 
             if self._frames is not None and self._frames.changed:
                 with open(self.frames_file, 'w+') as f:
-                    json.dump(self.frames.dump(), f, indent=1)
+                    json.dump(self.frames.dump(), f, indent=1,
+                              ensure_ascii=False)
 
             if self._config_changed:
                 with open(self.config_file, 'w+') as f:


### PR DESCRIPTION
Instead of showing escaped characters in editing mode:

```json
{
    "project": "a-cool-project",
    "start": "2015-10-19 13:27:11",
    "stop": "2015-10-19 14:53:08",
    "tags": [
        "\u91cd\u6784"
    ]
}
```

Escaped characters should be:

```json
{
    "project": "a-cool-project",
    "start": "2015-10-19 13:27:11",
    "stop": "2015-10-19 14:53:08",
    "tags": [
        "重构"
    ]
}
```

Which can give a better look.