### PR TITLE
Add flake8 to test environments to always run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = flake8,py27,py33,py34
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
So flake8 is always run locally, when you check our commits with tox, same as travis does and you don't get any surprises.