### PR TITLE
Add option to display program version (fixes #51)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Setup file for the Watson distribution."""
+
+from os.path import join
+
 from setuptools import setup
 
 with open('README.rst') as f:
     readme = f.read()
 
+# read package meta-data from version.py
+pkg = {}
+mod = join('watson', 'version.py')
+exec(compile(open(mod).read(), mod, 'exec'), {}, pkg)
+
 
 setup(
     name='td-watson',
-    version='1.1.0',
+    version=pkg['version'],
     description='A wonderful CLI to track your time!',
     packages=['watson'],
     author='TailorDev',

--- a/watson/__init__.py
+++ b/watson/__init__.py
@@ -1,3 +1,4 @@
+from .watson import __version__  # noqa
 from .watson import Watson, WatsonError
 
 __all__ = ['Watson', 'WatsonError']

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -72,6 +72,7 @@ Date = DateParamType()
 
 
 @click.group()
+@click.version_option(version=watson.__version__, prog_name='Watson')
 @click.pass_context
 def cli(ctx):
     """

--- a/watson/version.py
+++ b/watson/version.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+version = "1.1.0"

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -14,6 +14,7 @@ import requests
 
 from .config import ConfigParser
 from .frames import Frames
+from .version import version as __version__  # noqa
 
 
 class WatsonError(RuntimeError):


### PR DESCRIPTION
Moves the version number from `setup.py` into `watson/version.py`, from where it is imported by `watson/watson.py` and read via `exec` by `setup.py`. Exec is used, so that the version number isn't accidentally imported from an installed version of Watson. The version is in a separate module, so `setup.py` doesn't have to import/exec `watson/watson.py`, which would trigger dependencies. The mechanism can also be used to move additional package metadata - such as author, license, etc. - into `version.py` (it should then probably be renamed).

I used `"Watson"` (capitalized) as the program name, when displayed by click. I hope that's right, but it can easily be changed.