### PR TITLE
Add Python 3.5 to tox and travis config (fixes #44)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-  - "2.7"
+  - "3.5"
 env:
   - TOX_ENV=flake8
   - TOX_ENV=py27
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
 install:
   - pip install tox
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py33,py34
+envlist = flake8,py27,py33,py34,py35
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Run tox on travis via Python 3.5.

Fixes #44. Obsoletes #45.

The problem with Travis mentioned in #45 is that it does not find Python 3.5, when using the Python 2.7 environment. Since we use tox to run tests for different Python versions, the simple solution was to run tox always via Python 3.5. The magic trick with the build environment matrix mentioned [here](https://github.com/travis-ci/travis-ci/issues/4794#issuecomment-143568134) isn't needed in this case.