### PR TITLE
Implements rename command

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -270,6 +270,28 @@ Flag | Help
 `-f, --force` | Don't ask for confirmation.
 `--help` | Show this message and exit.
 
+## `rename`
+
+```bash
+Usage:  watson rename [OPTIONS] TYPE OLD_NAME NEW_NAME
+```
+
+Rename a project or tag.
+
+Example:
+
+
+    $ watson rename project read-python-intro learn-python
+    Renamed project "read-python-intro" to "learn-python"
+    $ watson rename tag company-meeting meeting
+    Renamed tag "company-meeting" to "meeting"
+
+### Options
+
+Flag | Help
+-----|-----
+`--help` | Show this message and exit.
+
 ## `report`
 
 ```bash
@@ -396,7 +418,7 @@ If there is already a running project and the configuration option
 `options.stop_on_start` is set to a true value (`1`, `on`, `true` or
 `yes`), it is stopped before the new project is started.
 
-Example :
+Example:
 
 
     $ watson start apollo11 +module +brakes

--- a/watson.completion
+++ b/watson.completion
@@ -6,7 +6,7 @@ _watson_complete () {
   local cur cmd commands frames projects tags
   local IFS=$'\n'
 
-  commands='cancel config edit frames help log merge projects remove report restart start status stop sync tags'
+  commands='cancel config edit frames help log merge projects remove rename report restart start status stop sync tags'
 
   cur=${COMP_WORDS[COMP_CWORD]}
   cmd=${COMP_WORDS[1]}
@@ -75,6 +75,18 @@ _watson_complete () {
             tags="$(watson tags | sed -e 's/ /\\\\ /g' | awk '$0="+"$0')"
             COMPREPLY=($(compgen -W "$tags" -- ${cur}))
           fi
+          ;;
+        rename)
+          case "$3" in
+            project)
+              projects="$(watson projects | sed -e 's/ /\\\\ /g')"
+              COMPREPLY=($(compgen -W "$projects" -- ${cur}))
+              ;;
+            tag)
+              tags="$(watson tags | sed -e 's/ /\\\\ /g')"
+              COMPREPLY=($(compgen -W "$tags" -- ${cur}))
+              ;;
+          esac
           ;;
       esac
       ;;

--- a/watson.zsh-completion
+++ b/watson.zsh-completion
@@ -10,6 +10,7 @@ _watson_commands=(
   'help:Display help information'
   'log:Display each recorded session during the...'
   'merge:Perform a merge of the existing frames with a...'
+  'rename:Rename a project or tag.'
   'projects:Display the list of all the existing...'
   'remove:Remove a frame.'
   'report:Display a report of the time spent on each...'
@@ -132,6 +133,12 @@ _watson() {
             '--help' \
             {-f,--force} \
             ': :_files'
+          ;;
+        (rename)
+          _arguments : \
+            '*'{project}'[rename given project]: :_watson_projects' \
+            '*'{tag}'[rename given tag]: :_watson_tags' \
+            '--help'
           ;;
       esac
       ;;


### PR DESCRIPTION
reopened because of #58 the pr #63 was closed. 

The following items will be done:
* [x] fix PEP8 issues
* [x] Short style flag -p would be relevant in line "@click.option('--project', default=None, nargs=2)"
* [x] Idem with -T for cross commands consistency in line "@click.option('--tag', default=None, nargs=2)"
* [x] same in file watson.completion
* [x] use _replace function: That way if we change the format of the frame we will not have to edit this function.
* [x] change

        if frame.project == old_project:
            frame._replace(project=new_project)

* [x] incorp. code review by @SpotlightKid 
* [x] change CLI from --tags to subsubcommand
* [x] rebase and squash

did I forget something?