### PR TITLE
Allow Watson's directory override by defining the WATSON_DIR environment variable

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -161,7 +161,7 @@ export WATSON_DIR=/path/to/watson/folder
 
 or when calling Watson:
 
-```
+```bash
 $ WATSON_DIR=/path/to/watson/folder watson status
 ```
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -2,7 +2,7 @@
 
 ## The configuration file
 
-Watson configuration and data are stored inside your user's application folder. Depending on your system it might be:
+Watson configuration and data are stored inside your user's application folder. Depending on your system, the default path might be:
 
 * **MacOSX**: `~/Library/Application Support/watson/config`
 * **Windows**: `C:\Users\<user>\AppData\Local\watson\config`
@@ -147,3 +147,22 @@ stop_on_restart = false
 date_format = '%Y.%m.%d'
 time_format = '%H:%M:%S%z'
 ```
+
+## Application folder
+
+To override Watson's default application folder (see first section), you can set the `$WATSON_DIR` environment variable to the desired path.
+
+It may be defined globally in your shell profile:
+
+```bash
+# .bashrc or .profile
+export WATSON_DIR=/path/to/watson/folder
+```
+
+or when calling Watson:
+
+```
+$ WATSON_DIR=/path/to/watson/folder watson status
+```
+
+This can be useful to preserve your real data when hacking with Watson :)

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 
-import json
 import datetime
-import operator
 import itertools
+import json
+import operator
+import os
 
-from functools import reduce
 from dateutil import tz
+from functools import reduce
 
-import click
 import arrow
+import click
 
 from . import watson
 from .frames import Frame
@@ -83,10 +84,10 @@ def cli(ctx):
     project with the `start` command, and you can stop the timer
     when you're done with the `stop` command.
     """
+
     # This is the main command group, needed by click in order
     # to handle the subcommands
-
-    ctx.obj = watson.Watson()
+    ctx.obj = watson.Watson(config_dir=os.environ.get('WATSON_DIR'))
 
 
 @cli.command()

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -50,7 +50,7 @@ class Watson(object):
         self._config = None
         self._config_changed = False
 
-        self._dir = kwargs.pop('config_dir', click.get_app_dir('watson'))
+        self._dir = kwargs.pop('config_dir') or click.get_app_dir('watson')
 
         self.config_file = os.path.join(self._dir, 'config')
         self.frames_file = os.path.join(self._dir, 'frames')


### PR DESCRIPTION
This could be really useful when using `Watson` to track your own time and working on a new feature without touching production data :)

There is no tests for this PR since:

* setting up the `config_dir`  when invoking `Watson` is already tested
* I am preparing a new PR to add tests for the CLI (see #5) and this PR needs a lot of aside preparation work that do not relate with this PR