### PR TITLE
Document how to obtain available distribution packages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,19 @@ $ pip install td-watson
 
 Depending on your system, you might need to run this command with root privileges in order to install Watson globally.
 
+### Distribution packages
+
+You can install Watson using available distribution packages.
+
+**Arch Linux**
+
+A PKGBUILD file for building an Arch Linux package is Available in the
+[AUR](https://aur.archlinux.org/packages/watson/). Build and install
+using the [makepkg](https://wiki.archlinux.org/index.php/Makepkg) or an
+[AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). Please
+refer to the official documentation for more information on installing
+AUR packages.
+
 ### Single user installation
 
 You can choose to install Watson for your user only by running:


### PR DESCRIPTION
For easier system maintenance some vendors recommend installing software
using distribution packages. This pull request adds documentation for
obtaining Watston on Arch Linux based systems.

More distributions might decide to package Watson in the future.