### PR TITLE
Require "pytest-runner" as development dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,5 @@ flake8
 mock<=1.0.1
 pytest
 pytest-datafiles
+pytest-runner
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 arrow
 click
-pytest-runner
 requests


### PR DESCRIPTION
Requiring "pytest-runner" as an install dependency adds unnecessary
bloat to the end user package. Instead, only development build should
require "pytest-runner" as a dependency.