### PR TITLE
Improve selecting frame by position in the cli

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -56,11 +56,9 @@ Usage:  watson edit [OPTIONS] [ID]
 
 Edit a frame.
 
-You can specify the frame to edit with an integer frame index or a frame
-id. For example, to edit the second-to-last frame, pass `-2` as the frame
-index (put ` -- ` in front of negative indexes to prevent them from being
-interpreted as an option). You can get the id of a frame with the `watson
-log` command.
+You can specify the frame to edit by its position or by its frame id.
+For example, to edit the second-to-last frame, pass `-2` as the frame
+index. You can get the id of a frame with the `watson log` command.
 
 If no id or index is given, the frame defaults to the current frame or the
 last recorded frame, if no project is currently running.
@@ -262,7 +260,8 @@ Flag | Help
 Usage:  watson remove [OPTIONS] ID
 ```
 
-Remove a frame.
+Remove a frame. You can specify the frame either by id or by position
+(ex: `-1` for the last frame).
 
 ### Options
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -670,12 +670,11 @@ def edit(watson, id):
 @click.pass_obj
 def remove(watson, id, force):
     """
-    Remove a frame.
+    Remove a frame. You can specify the frame either by id or by position
+    (ex: `-1` for the last frame).
     """
-    try:
-        frame = watson.frames[id]
-    except KeyError:
-        raise click.ClickException("No frame found with id {}.".format(id))
+    frame = get_frame_from_argument(watson, id)
+    id = frame.id
 
     if not force:
         click.confirm(

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -14,39 +14,7 @@ import click
 
 from . import watson
 from .frames import Frame
-from .utils import format_timedelta, sorted_groupby, options
-
-
-def style(name, element):
-    def _style_tags(tags):
-        if not tags:
-            return ''
-
-        return '[{}]'.format(', '.join(
-            style('tag', tag) for tag in tags
-        ))
-
-    def _style_short_id(id):
-        return style('id', id[:7])
-
-    formats = {
-        'project': {'fg': 'magenta'},
-        'tags': _style_tags,
-        'tag': {'fg': 'blue'},
-        'time': {'fg': 'green'},
-        'error': {'fg': 'red'},
-        'date': {'fg': 'cyan'},
-        'short_id': _style_short_id,
-        'id': {'fg': 'white'}
-    }
-
-    fmt = formats.get(name, {})
-
-    if isinstance(fmt, dict):
-        return click.style(element, **fmt)
-    else:
-        # The fmt might be a function if we need to do some computation
-        return fmt(element)
+from .utils import style, format_timedelta, sorted_groupby, options
 
 
 class WatsonCliError(click.ClickException):

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -155,7 +155,7 @@ def stop(watson):
     watson.save()
 
 
-@cli.command()
+@cli.command(context_settings={'ignore_unknown_options': True})
 @click.option('-s/-S', '--stop/--no-stop', 'stop_', default=None,
               help="(Don't) Stop an already running project.")
 @click.argument('frame', default='-1')
@@ -571,18 +571,16 @@ def frames(watson):
         click.echo(style('short_id', frame.id))
 
 
-@cli.command()
+@cli.command(context_settings={'ignore_unknown_options': True})
 @click.argument('id', required=False)
 @click.pass_obj
 def edit(watson, id):
     """
     Edit a frame.
 
-    You can specify the frame to edit with an integer frame index or a frame
-    id. For example, to edit the second-to-last frame, pass `-2` as the frame
-    index (put ` -- ` in front of negative indexes to prevent them from being
-    interpreted as an option). You can get the id of a frame with the `watson
-    log` command.
+    You can specify the frame to edit by its position or by its frame id.
+    For example, to edit the second-to-last frame, pass `-2` as the frame
+    index. You can get the id of a frame with the `watson log` command.
 
     If no id or index is given, the frame defaults to the current frame or the
     last recorded frame, if no project is currently running.
@@ -663,7 +661,7 @@ def edit(watson, id):
     )
 
 
-@cli.command()
+@cli.command(context_settings={'ignore_unknown_options': True})
 @click.argument('id')
 @click.option('-f', '--force', is_flag=True,
               help="Don't ask for confirmation.")

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -14,7 +14,8 @@ import click
 
 from . import watson
 from .frames import Frame
-from .utils import style, format_timedelta, sorted_groupby, options
+from .utils import (format_timedelta, get_frame_from_argument, options,
+                    sorted_groupby, style)
 
 
 class WatsonCliError(click.ClickException):
@@ -206,18 +207,7 @@ def restart(ctx, watson, frame, stop_):
                 style('project', watson.current['project']),
                 style('tags', watson.current['tags'])))
 
-    try:
-        frame = watson.frames[int(frame)]
-    except IndexError:
-        raise click.ClickException(
-            style('error', "Frame index {} not in range.".format(frame)))
-    except (TypeError, ValueError):
-        try:
-            frame = watson.frames[frame]
-        except KeyError:
-            raise click.ClickException("{} {}.".format(
-                style('error', "No frame found with id"),
-                style('short_id', frame)))
+    frame = get_frame_from_argument(watson, frame)
 
     _start(watson, frame.project, frame.tags)
 
@@ -605,18 +595,8 @@ def edit(watson, id):
     local_tz = tz.tzlocal()
 
     if id:
-        try:
-            frame = watson.frames[int(id)]
-        except IndexError:
-            raise click.ClickException(
-                style('error', "Frame index {} not in range.".format(id)))
-        except (TypeError, ValueError):
-            try:
-                frame = watson.frames[id]
-            except KeyError:
-                raise click.ClickException("{} {}.".format(
-                    style('error', "No frame found with id"),
-                    style('short_id', id)))
+        frame = get_frame_from_argument(watson, id)
+        id = frame.id
     elif watson.is_started:
         frame = Frame(watson.current['start'], None, watson.current['project'],
                       None, watson.current['tags'])

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -82,3 +82,32 @@ def options(opt_list):
             raise UsageError("Response should be one of [{}]".format(
                 ','.join(str(x) for x in opt_list)))
     return value_proc
+
+
+def get_frame_from_argument(watson, arg):
+    """
+    Get a frame from a command line argument which can either be a
+    position index (-1) or a frame id.
+    """
+    # first we try to see if we are refering to a frame by
+    # its position (for example -2). We only take negative indexes
+    # as a positive index might also be an existing id
+    try:
+        index = int(arg)
+        if index < 0:
+            return watson.frames[index]
+    except IndexError:
+        raise click.ClickException(
+            style('error', "No frame found for index {}.".format(arg))
+        )
+    except (ValueError, TypeError):
+        pass
+
+    # if we didn't find a frame by position, we try by id
+    try:
+        return watson.frames[arg]
+    except KeyError:
+        raise click.ClickException("{} {}.".format(
+            style('error', "No frame found with id"),
+            style('short_id', arg))
+        )

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -1,6 +1,40 @@
 import itertools
 
+import click
+
 from click.exceptions import UsageError
+
+
+def style(name, element):
+    def _style_tags(tags):
+        if not tags:
+            return ''
+
+        return '[{}]'.format(', '.join(
+            style('tag', tag) for tag in tags
+        ))
+
+    def _style_short_id(id):
+        return style('id', id[:7])
+
+    formats = {
+        'project': {'fg': 'magenta'},
+        'tags': _style_tags,
+        'tag': {'fg': 'blue'},
+        'time': {'fg': 'green'},
+        'error': {'fg': 'red'},
+        'date': {'fg': 'cyan'},
+        'short_id': _style_short_id,
+        'id': {'fg': 'white'}
+    }
+
+    fmt = formats.get(name, {})
+
+    if isinstance(fmt, dict):
+        return click.style(element, **fmt)
+    else:
+        # The fmt might be a function if we need to do some computation
+        return fmt(element)
 
 
 def format_timedelta(delta):


### PR DESCRIPTION
I did a bit of refactoring around positional indexes in the cli.

- Commands accepting a frame index only accept negative numbers (`watson edit -1` but not `watson edit 3`). It wasn't making much sense IMO.
- Fixes #98 (editing a frame having a numerical id)
- Fixes an issue were `watson edit -2` was actually creating a frame with the id "-2"
- It's no longer necessary to add `--` before a negative index (you no longer need to type `watson edit -- -2`, yay!)
- `watson remove` accept an index or an id