### PR TITLE
Specify correct source directory for flake8 and pytest in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist = flake8,py27,py33,py34,py35
 deps=pytest
      mock
      pytest-datafiles
-commands=py.test -vs
+commands=py.test -vs tests/
 usedevelop=True
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 --show-source .
+commands = flake8 --show-source watson/ tests/ scripts/


### PR DESCRIPTION
If the tests directory is not specified this causes problems if the
developer has virtualenvs setup in the Watson root directory.
The packages in there could include tests which are then run by tox.

Same for flake8 and the watson and tests directory.