### PR TITLE
Leverage arrow timedelta property to simplify format_timedelta()

### DIFF
--- a/watson/utils.py
+++ b/watson/utils.py
@@ -40,9 +40,20 @@ def style(name, element):
 def format_timedelta(delta):
     """
     Return a string roughly representing a timedelta.
+
+    For reference, str(timedelta) returns [x days,] hh:mm:ss
+
     """
     neg = '-' if int(delta.total_seconds()) < 0 else ''
-    res = "{}h {}m {}s".format(*str(abs(delta)).split(":"))
+    fmt = ["{}h ", "{}m ", "{}s"]
+    td = str(abs(delta)).split(":")
+    td[:0] = td.pop(0).split(',')
+    if len(td) == 4:
+        add_hours = int(td.pop(0).split()[0].strip()) * 24
+        td[0] = str(int(td[0]) + add_hours)
+    res = str()
+    for f, k in zip(fmt, td):
+        res += f.format(k.strip()) if int(k) else ''
     return "{}{}".format(neg, res)
 
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -41,25 +41,9 @@ def format_timedelta(delta):
     """
     Return a string roughly representing a timedelta.
     """
-    seconds = int(delta.total_seconds())
-    neg = seconds < 0
-    seconds = abs(seconds)
-    total = seconds
-    stems = []
-
-    if total >= 3600:
-        hours = seconds // 3600
-        stems.append('{}h'.format(hours))
-        seconds -= hours * 3600
-
-    if total >= 60:
-        mins = seconds // 60
-        stems.append('{:02}m'.format(mins))
-        seconds -= mins * 60
-
-    stems.append('{:02}s'.format(seconds))
-
-    return ('-' if neg else '') + ' '.join(stems)
+    neg = '-' if int(delta.total_seconds()) < 0 else ''
+    res = "{}h {}m {}s".format(*str(abs(delta)).split(":"))
+    return "{}{}".format(neg, res)
 
 
 def sorted_groupby(iterator, key, reverse=False):


### PR DESCRIPTION
Hey, I was perusing the code looking to make some feature requests and I noticed completely by accident that the format_timedelta function can be simplified by using a feature of arrow that returns `hh:mm:ss` on a `str(delta)`. Nice! Works for any value from 0 on up. If it goes into days, it just looks like `x days hh:mm:ss` which still works perfectly with this PR.

Thanks for a great app!

Scott