### PR TITLE
Rounding of work times up to nearest x minutes

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -156,6 +156,19 @@ Example:
     Wednesday 16 April 2014 (5h 19m 18s)
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
+    
+    $ watson log --from 2016-02-16 --to 2016-03-15 --round_to 15
+    Friday 04 March 2016 (1h 45m 00s)
+            d7f7cd0  13:57 to 14:17      19m 23s  apollo11  [wheels]
+            4cc9841  14:27 to 15:11      43m 42s  apollo11  [lens]
+            ce3d2aa  16:29 to 17:06      36m 41s  apollo11  [reactor]
+    
+    Tuesday 23 February 2016 (2h 30m 00s)
+            6931d90  12:04 to 12:06      02m 02s  apollo11  [antenna]
+            f0d473c  12:06 to 13:15   1h 08m 32s  apollo11  [antenna]
+            678d9af  13:55 to 14:09      14m 04s  apollo11  [antenna]
+            ae51e4d  14:28 to 14:51      23m 18s  apollo11  [antenna]
+            6fe0aa3  20:26 to 21:01      34m 11s  apollo11  [antenna]
 
 ### Options
 
@@ -165,7 +178,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the log should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`-r, --round-to INTEGER` | Rounds log values up to the nearest x minutes.Defaults to no rounding.
+`-r, --round-to INTEGER` | Rounds daily totals up to the nearest x minutes. Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `merge`
@@ -340,6 +353,16 @@ Example:
             [reactor   8h 35m 50s]
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
+    
+    $ watson report --from 2016-02-10 --to 2016-03-30 --round_to 15
+    Wed 10 February 2016 -> Wed 30 March 2016
+    
+    apollo11 - 22h 45m 00s
+            [brakes   1h 00m 00s]
+            [module  13h 00m 00s]
+            [reactor  7h 15m 00s]
+            [steering 1h 30m 00s]
+            [wheels      45m 00s]
 
 ### Options
 
@@ -349,7 +372,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`-r, --round_to INTEGER` | Rounds the total time for each day of work values up to the nearest x minutes. Defaults to no rounding.
+`-r, --round_to INTEGER` | Rounds the total time for each day of work up to the nearest x minutes. Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `restart`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -124,6 +124,10 @@ You can limit the log to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the log.
 
+Total times can be rounded to the nearest x minutes with the `--round_to`
+option. The totals are rounded for each calendar day of work, not for each
+frame.
+
 Example:
 
 
@@ -161,6 +165,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the log should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-r, --round-to INTEGER` | Rounds log values up to the nearest x minutes.Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `merge`
@@ -290,6 +295,10 @@ You can limit the report to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the report.
 
+Total times can be rounded to the nearest x minutes with the `--round_to`
+option. The totals are rounded for each calendar day of work, not for each
+frame.
+
 Example:
 
 
@@ -340,6 +349,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-r, --round_to INTEGER` | Rounds the total time for each day of work values up to the nearest x minutes. Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `restart`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -130,6 +130,10 @@ Globally configure how `dates` should be formatted. All [python's `strftime` dir
 
 Globally configure how `time` should be formatted. All [python's `strftime` directives](http://strftime.org) are supported.
 
+#### `options.round_to`
+
+Round report and log work total times up to the nearest x minutes. Defaults to 0 min (no rounding).
+
 ## Sample configuration file
 
 A basic configuration file looks like the following:
@@ -146,6 +150,7 @@ stop_on_start = true
 stop_on_restart = false
 date_format = '%Y.%m.%d'
 time_format = '%H:%M:%S%z'
+round_to = 15
 ```
 
 ## Application folder

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -20,6 +20,7 @@ import arrow
 from click import get_app_dir
 from watson import Watson, WatsonError
 from watson.watson import ConfigurationError, ConfigParser
+from watson.utils import format_timedelta
 
 TEST_FIXTURE_DIR = py.path.local(
     os.path.dirname(
@@ -781,3 +782,25 @@ def test_merge_report(watson, datafiles):
 
     assert conflicting[0].id == '2'
     assert merging[0].id == '3'
+
+# format_datetime
+
+
+def test_format_timedelta_and_rounding(watson):
+    # Test round_to = (0, 1, 5, 10, 15, 30, 60)
+    # times = {(xx h, xx m, xx sec): ("res for 0 round", "res for 1 round"...)}
+    times = {(0, 0, 0): ("00s", "00s", "00s", "00s", "00s", "00s", "00s"),
+             (0, 4, 23): ("04m 23s", "04m 00s", "05m 00s", "10m 00s",
+                          "15m 00s", "30m 00s", "1h 00m 00s"),
+             (0, 10, 00): ("10m 00s", "10m 00s", "10m 00s", "10m 00s",
+                           "15m 00s", "30m 00s", "1h 00m 00s"),
+             (23, 53, 32): ("23h 53m 32s", "23h 54m 00s", "23h 55m 00s",
+                            "24h 00m 00s", "24h 00m 00s", "24h 00m 00s",
+                            "24h 00m 00s")
+             }
+    round_to = (0, 1, 5, 10, 15, 30, 60)
+    for t, res in times.items():
+        h, m, s = t
+        for r, rt in enumerate(round_to):
+            td = arrow.arrow.timedelta(hours=h, minutes=m, seconds=s)
+            assert format_timedelta(td, round_up_to=rt) == res[r]

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -279,7 +279,7 @@ def status(watson):
               help="Reports activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
-@click.option('-r', '--round_to', type=int, default=0,
+@click.option('-r', '--round_to', type=int, default=None,
               help="Rounds the total time for each day of work values up to "
               "the nearest x minutes. Defaults to no rounding.")
 @click.pass_obj
@@ -298,6 +298,10 @@ def report(watson, from_, to, projects, tags, round_to):
     You can limit the report to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
     projects or tags to the report.
+
+    Total times can be rounded to the nearest x minutes with the `--round_to`
+    option. The totals are rounded for each calendar day of work, not for each
+    frame.
 
     Example:
 
@@ -343,6 +347,12 @@ def report(watson, from_, to, projects, tags, round_to):
     """
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
+
+    if watson.config.has_option('options', 'round_to') is True \
+            and round_to is None:
+        round_to = int(watson.config.get('options', 'round_to'))
+    else:
+        round_to = round_to or 0
 
     span = watson.frames.span(from_, to)
 
@@ -406,7 +416,7 @@ def report(watson, from_, to, projects, tags, round_to):
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
-@click.option('-r', '--round-to', type=int, default=0,
+@click.option('-r', '--round-to', type=int, default=None,
               help="Rounds log values up to the nearest x minutes."
               "Defaults to no rounding.")
 @click.pass_obj
@@ -421,6 +431,10 @@ def log(watson, from_, to, projects, tags, round_to):
     You can limit the log to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
     projects or tags to the log.
+
+    Total times can be rounded to the nearest x minutes with the `--round_to`
+    option. The totals are rounded for each calendar day of work, not for each
+    frame.
 
     Example:
 
@@ -453,6 +467,12 @@ def log(watson, from_, to, projects, tags, round_to):
     """  # noqa
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
+
+    if watson.config.has_option('options', 'round_to') is True \
+            and round_to is None:
+        round_to = int(watson.config.get('options', 'round_to'))
+    else:
+        round_to = round_to or 0
 
     span = watson.frames.span(from_, to)
     frames_by_day = sorted_groupby(

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -280,7 +280,7 @@ def status(watson):
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.option('-r', '--round_to', type=int, default=None,
-              help="Rounds the total time for each day of work values up to "
+              help="Rounds the total time for each day of work up to "
               "the nearest x minutes. Defaults to no rounding.")
 @click.pass_obj
 def report(watson, from_, to, projects, tags, round_to):
@@ -344,6 +344,16 @@ def report(watson, from_, to, projects, tags, round_to):
             [reactor   8h 35m 50s]
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
+    \b
+    $ watson report --from 2016-02-10 --to 2016-03-30 --round_to 15
+    Wed 10 February 2016 -> Wed 30 March 2016
+    \b
+    apollo11 - 22h 45m 00s
+            [brakes   1h 00m 00s]
+            [module  13h 00m 00s]
+            [reactor  7h 15m 00s]
+            [steering 1h 30m 00s]
+            [wheels      45m 00s]
     """
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
@@ -417,7 +427,7 @@ def report(watson, from_, to, projects, tags, round_to):
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.option('-r', '--round-to', type=int, default=None,
-              help="Rounds log values up to the nearest x minutes."
+              help="Rounds daily totals up to the nearest x minutes. "
               "Defaults to no rounding.")
 @click.pass_obj
 def log(watson, from_, to, projects, tags, round_to):
@@ -464,6 +474,19 @@ def log(watson, from_, to, projects, tags, round_to):
     Wednesday 16 April 2014 (5h 19m 18s)
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
+    \b
+    $ watson log --from 2016-02-16 --to 2016-03-15 --round_to 15
+    Friday 04 March 2016 (1h 45m 00s)
+            d7f7cd0  13:57 to 14:17      19m 23s  apollo11  [wheels]
+            4cc9841  14:27 to 15:11      43m 42s  apollo11  [lens]
+            ce3d2aa  16:29 to 17:06      36m 41s  apollo11  [reactor]
+    \b
+    Tuesday 23 February 2016 (2h 30m 00s)
+            6931d90  12:04 to 12:06      02m 02s  apollo11  [antenna]
+            f0d473c  12:06 to 13:15   1h 08m 32s  apollo11  [antenna]
+            678d9af  13:55 to 14:09      14m 04s  apollo11  [antenna]
+            ae51e4d  14:28 to 14:51      23m 18s  apollo11  [antenna]
+            6fe0aa3  20:26 to 21:01      34m 11s  apollo11  [antenna]
     """  # noqa
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -426,7 +426,7 @@ def report(watson, from_, to, projects, tags, round_to):
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
-@click.option('-r', '--round-to', type=int, default=None,
+@click.option('-r', '--round_to', type=int, default=None,
               help="Rounds daily totals up to the nearest x minutes. "
               "Defaults to no rounding.")
 @click.pass_obj

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -1,8 +1,6 @@
-import itertools
-
 import click
-
 import datetime
+import itertools
 
 from click.exceptions import UsageError
 
@@ -66,20 +64,28 @@ def format_timedelta(delta, round_up_to=0):
     return ('-' if neg else '') + ' '.join(stems)
 
 
-def round_time(dt=None, round_up_to=0):
+def round_time(dt, round_up_to=0):
     """
-    Round a datetime object up to nearest round_to minutes
+    Round a datetime object _up_ to nearest round_to minutes.
+
+    First round seconds up or down to the nearest minute, then round that
+    result up to the nearest round_to minute.
 
     Set round_up_to=0 for no rounding
+
     """
-    round_dt = datetime.timedelta(minutes=round_up_to).total_seconds()
-    if dt is None:
-        dt = datetime.now()
     if round_up_to == 0:
         return dt
-    seconds = (dt - dt.min).seconds
+    round_dt = datetime.timedelta(minutes=round_up_to).total_seconds()
+    seconds = int(dt.total_seconds())
+    rounding = (seconds + 60 / 2) // 60 * 60
+    dt += datetime.timedelta(0, rounding - seconds)
+    seconds = int(dt.total_seconds())
     rounding = (seconds + round_dt) // round_dt * round_dt
-    return dt + datetime.timedelta(0, rounding - seconds)
+    if dt.total_seconds() % (round_up_to * 60) != 0:
+        return dt + datetime.timedelta(0, rounding - seconds)
+    else:
+        return dt
 
 
 def sorted_groupby(iterator, key, reverse=False):

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -2,6 +2,8 @@ import itertools
 
 import click
 
+import datetime
+
 from click.exceptions import UsageError
 
 
@@ -37,10 +39,12 @@ def style(name, element):
         return fmt(element)
 
 
-def format_timedelta(delta):
+def format_timedelta(delta, round_up_to=0):
     """
-    Return a string roughly representing a timedelta.
+    Return a string roughly representing a timedelta. Round up to `round_up_to`
+    minutes. No rounding by default.
     """
+    delta = round_time(delta, round_up_to)
     seconds = int(delta.total_seconds())
     neg = seconds < 0
     seconds = abs(seconds)
@@ -62,12 +66,47 @@ def format_timedelta(delta):
     return ('-' if neg else '') + ' '.join(stems)
 
 
+def round_time(dt=None, round_up_to=0):
+    """
+    Round a datetime object up to nearest round_to minutes
+
+    Set round_up_to=0 for no rounding
+    """
+    round_dt = datetime.timedelta(minutes=round_up_to).total_seconds()
+    if dt is None:
+        dt = datetime.now()
+    if round_up_to == 0:
+        return dt
+    seconds = (dt - dt.min).seconds
+    rounding = (seconds + round_dt) // round_dt * round_dt
+    return dt + datetime.timedelta(0, rounding - seconds)
+
+
 def sorted_groupby(iterator, key, reverse=False):
     """
     Similar to `itertools.groupby`, but sorts the iterator with the same
     key first.
     """
     return itertools.groupby(sorted(iterator, key=key, reverse=reverse), key)
+
+
+def total_by_day(frames, round_to=0, tag=None):
+    """
+    Given an iterator of Frame objects, return a total result where the time
+    for each day is summed and then rounded up to round_to. The rounded totals
+    for each day (and for a tag if given) are then summed without rounding and
+    returned as the result.
+    """
+    frames = list((i for i in frames if not tag or tag in i.tags))
+    days = [list(group) for k, group in
+            sorted_groupby(frames,
+                           key=lambda x: x.start.datetime.toordinal())]
+    delta = []
+    for day in days:
+        day_iter = (f.stop - f.start for f in day)
+        delta.append(round_time(sum(day_iter, datetime.timedelta()),
+                                round_to))
+    return sum(delta, datetime.timedelta())
 
 
 def options(opt_list):


### PR DESCRIPTION
This is an initial commit (no docs or tests yet) of a feature to offer rounding up of work times. I wanted to make sure this would be of interest before I finalize it.

Rationale: I don't think most people track their work times to the nearest second. Also, a number of contractors round times up to the nearest hour or half-hour. 

Changes: added a command-line switch --round-to (-r). Defaults to zero (no rounding). The rounding feature rounds the totals for each day based on the start time. So if you have multiple frames in a day, it will sum all of the frames, then present the rounded-up total for that day. It works with both the 'report' and 'log' options. The time per day is also summed and rounded for each tag in the log view.

I've attached a file with sample outputs with and without rounding.

Let me know if this makes sense and seems useful. 

Scott
[log.txt](https://github.com/TailorDev/Watson/files/160088/log.txt)
