### PR TITLE
Add rounding option for total work times and changes default report view style.

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -156,6 +156,19 @@ Example:
     Wednesday 16 April 2014 (5h 19m 18s)
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
+    
+    $ watson log --from 2016-02-16 --to 2016-03-15 --round_to 15
+    Friday 04 March 2016 (1h 45m 00s)
+            d7f7cd0  13:57 to 14:17      19m 23s  apollo11  [wheels]
+            4cc9841  14:27 to 15:11      43m 42s  apollo11  [lens]
+            ce3d2aa  16:29 to 17:06      36m 41s  apollo11  [reactor]
+    
+    Tuesday 23 February 2016 (2h 30m 00s)
+            6931d90  12:04 to 12:06      02m 02s  apollo11  [antenna]
+            f0d473c  12:06 to 13:15   1h 08m 32s  apollo11  [antenna]
+            678d9af  13:55 to 14:09      14m 04s  apollo11  [antenna]
+            ae51e4d  14:28 to 14:51      23m 18s  apollo11  [antenna]
+            6fe0aa3  20:26 to 21:01      34m 11s  apollo11  [antenna]
 
 ### Options
 
@@ -165,7 +178,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the log should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`-r, --round-to INTEGER` | Rounds log values up to the nearest x minutes.Defaults to no rounding.
+`-r, --round-to INTEGER` | Rounds daily totals up to the nearest x minutes. Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `merge`
@@ -340,6 +353,16 @@ Example:
             [reactor   8h 35m 50s]
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
+    
+    $ watson report --from 2016-02-10 --to 2016-03-30 --round_to 15
+    Wed 10 February 2016 -> Wed 30 March 2016
+    
+    apollo11 - 22h 45m 00s
+            [brakes   1h 00m 00s]
+            [module  13h 00m 00s]
+            [reactor  7h 15m 00s]
+            [steering 1h 30m 00s]
+            [wheels      45m 00s]
 
 ### Options
 
@@ -349,7 +372,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`-r, --round_to INTEGER` | Rounds the total time for each day of work values up to the nearest x minutes. Defaults to no rounding.
+`-r, --round_to INTEGER` | Rounds the total time for each day of work up to the nearest x minutes. Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `restart`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -124,6 +124,10 @@ You can limit the log to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the log.
 
+Total times can be rounded to the nearest x minutes with the `--round_to`
+option. The totals are rounded for each calendar day of work, not for each
+frame.
+
 Example:
 
 
@@ -161,6 +165,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the log should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-r, --round-to INTEGER` | Rounds log values up to the nearest x minutes.Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `merge`
@@ -290,6 +295,10 @@ You can limit the report to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the report.
 
+Total times can be rounded to the nearest x minutes with the `--round_to`
+option. The totals are rounded for each calendar day of work, not for each
+frame.
+
 Example:
 
 
@@ -340,6 +349,7 @@ Flag | Help
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-r, --round_to INTEGER` | Rounds the total time for each day of work values up to the nearest x minutes. Defaults to no rounding.
 `--help` | Show this message and exit.
 
 ## `restart`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -130,6 +130,10 @@ Globally configure how `dates` should be formatted. All [python's `strftime` dir
 
 Globally configure how `time` should be formatted. All [python's `strftime` directives](http://strftime.org) are supported.
 
+#### `options.round_to`
+
+Round report and log work total times up to the nearest x minutes. Defaults to 0 min (no rounding).
+
 ## Sample configuration file
 
 A basic configuration file looks like the following:
@@ -146,6 +150,7 @@ stop_on_start = true
 stop_on_restart = false
 date_format = '%Y.%m.%d'
 time_format = '%H:%M:%S%z'
+round_to = 15
 ```
 
 ## Application folder

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -783,20 +783,21 @@ def test_merge_report(watson, datafiles):
     assert conflicting[0].id == '2'
     assert merging[0].id == '3'
 
-# format_datetime
 
+# format_datetime
 
 def test_format_timedelta_and_rounding(watson):
     # Test round_to = (0, 1, 5, 10, 15, 30, 60)
     # times = {(xx h, xx m, xx sec): ("res for 0 round", "res for 1 round"...)}
-    times = {(0, 0, 0): ("00s", "00s", "00s", "00s", "00s", "00s", "00s"),
-             (0, 4, 23): ("04m 23s", "04m 00s", "05m 00s", "10m 00s",
-                          "15m 00s", "30m 00s", "1h 00m 00s"),
-             (0, 10, 00): ("10m 00s", "10m 00s", "10m 00s", "10m 00s",
-                           "15m 00s", "30m 00s", "1h 00m 00s"),
-             (23, 53, 32): ("23h 53m 32s", "23h 54m 00s", "23h 55m 00s",
-                            "24h 00m 00s", "24h 00m 00s", "24h 00m 00s",
-                            "24h 00m 00s")
+    times = {(0, 0, 0): ("0h 00m 00s", "0h 00m", "0h 00m", "0h 00m", "0h 00m",
+                         "0h 00m", "0h 00m"),
+             (0, 4, 23): ("0h 04m 23s", "0h 04m", "0h 05m", "0h 10m",
+                          "0h 15m", "0h 30m", "1h 00m"),
+             (0, 10, 00): ("0h 10m 00s", "0h 10m", "0h 10m", "0h 10m",
+                           "0h 15m", "0h 30m", "1h 00m"),
+             (23, 53, 32): ("23h 53m 32s", "23h 54m", "23h 55m",
+                            "24h 00m", "24h 00m", "24h 00m",
+                            "24h 00m")
              }
     round_to = (0, 1, 5, 10, 15, 30, 60)
     for t, res in times.items():

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -20,6 +20,7 @@ import arrow
 from click import get_app_dir
 from watson import Watson, WatsonError
 from watson.watson import ConfigurationError, ConfigParser
+from watson.utils import format_timedelta
 
 TEST_FIXTURE_DIR = py.path.local(
     os.path.dirname(
@@ -781,3 +782,25 @@ def test_merge_report(watson, datafiles):
 
     assert conflicting[0].id == '2'
     assert merging[0].id == '3'
+
+# format_datetime
+
+
+def test_format_timedelta_and_rounding(watson):
+    # Test round_to = (0, 1, 5, 10, 15, 30, 60)
+    # times = {(xx h, xx m, xx sec): ("res for 0 round", "res for 1 round"...)}
+    times = {(0, 0, 0): ("00s", "00s", "00s", "00s", "00s", "00s", "00s"),
+             (0, 4, 23): ("04m 23s", "04m 00s", "05m 00s", "10m 00s",
+                          "15m 00s", "30m 00s", "1h 00m 00s"),
+             (0, 10, 00): ("10m 00s", "10m 00s", "10m 00s", "10m 00s",
+                           "15m 00s", "30m 00s", "1h 00m 00s"),
+             (23, 53, 32): ("23h 53m 32s", "23h 54m 00s", "23h 55m 00s",
+                            "24h 00m 00s", "24h 00m 00s", "24h 00m 00s",
+                            "24h 00m 00s")
+             }
+    round_to = (0, 1, 5, 10, 15, 30, 60)
+    for t, res in times.items():
+        h, m, s = t
+        for r, rt in enumerate(round_to):
+            td = arrow.arrow.timedelta(hours=h, minutes=m, seconds=s)
+            assert format_timedelta(td, round_up_to=rt) == res[r]

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -279,7 +279,7 @@ def status(watson):
               help="Reports activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
-@click.option('-r', '--round_to', type=int, default=0,
+@click.option('-r', '--round_to', type=int, default=None,
               help="Rounds the total time for each day of work values up to "
               "the nearest x minutes. Defaults to no rounding.")
 @click.pass_obj
@@ -298,6 +298,10 @@ def report(watson, from_, to, projects, tags, round_to):
     You can limit the report to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
     projects or tags to the report.
+
+    Total times can be rounded to the nearest x minutes with the `--round_to`
+    option. The totals are rounded for each calendar day of work, not for each
+    frame.
 
     Example:
 
@@ -343,6 +347,12 @@ def report(watson, from_, to, projects, tags, round_to):
     """
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
+
+    if watson.config.has_option('options', 'round_to') is True \
+            and round_to is None:
+        round_to = int(watson.config.get('options', 'round_to'))
+    else:
+        round_to = round_to or 0
 
     span = watson.frames.span(from_, to)
 
@@ -406,7 +416,7 @@ def report(watson, from_, to, projects, tags, round_to):
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
-@click.option('-r', '--round-to', type=int, default=0,
+@click.option('-r', '--round-to', type=int, default=None,
               help="Rounds log values up to the nearest x minutes."
               "Defaults to no rounding.")
 @click.pass_obj
@@ -421,6 +431,10 @@ def log(watson, from_, to, projects, tags, round_to):
     You can limit the log to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
     projects or tags to the log.
+
+    Total times can be rounded to the nearest x minutes with the `--round_to`
+    option. The totals are rounded for each calendar day of work, not for each
+    frame.
 
     Example:
 
@@ -453,6 +467,12 @@ def log(watson, from_, to, projects, tags, round_to):
     """  # noqa
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
+
+    if watson.config.has_option('options', 'round_to') is True \
+            and round_to is None:
+        round_to = int(watson.config.get('options', 'round_to'))
+    else:
+        round_to = round_to or 0
 
     span = watson.frames.span(from_, to)
     frames_by_day = sorted_groupby(

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -280,7 +280,7 @@ def status(watson):
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.option('-r', '--round_to', type=int, default=None,
-              help="Rounds the total time for each day of work values up to "
+              help="Rounds the total time for each day of work up to "
               "the nearest x minutes. Defaults to no rounding.")
 @click.pass_obj
 def report(watson, from_, to, projects, tags, round_to):
@@ -344,6 +344,16 @@ def report(watson, from_, to, projects, tags, round_to):
             [reactor   8h 35m 50s]
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
+    \b
+    $ watson report --from 2016-02-10 --to 2016-03-30 --round_to 15
+    Wed 10 February 2016 -> Wed 30 March 2016
+    \b
+    apollo11 - 22h 45m 00s
+            [brakes   1h 00m 00s]
+            [module  13h 00m 00s]
+            [reactor  7h 15m 00s]
+            [steering 1h 30m 00s]
+            [wheels      45m 00s]
     """
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
@@ -417,7 +427,7 @@ def report(watson, from_, to, projects, tags, round_to):
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.option('-r', '--round-to', type=int, default=None,
-              help="Rounds log values up to the nearest x minutes."
+              help="Rounds daily totals up to the nearest x minutes. "
               "Defaults to no rounding.")
 @click.pass_obj
 def log(watson, from_, to, projects, tags, round_to):
@@ -464,6 +474,19 @@ def log(watson, from_, to, projects, tags, round_to):
     Wednesday 16 April 2014 (5h 19m 18s)
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
+    \b
+    $ watson log --from 2016-02-16 --to 2016-03-15 --round_to 15
+    Friday 04 March 2016 (1h 45m 00s)
+            d7f7cd0  13:57 to 14:17      19m 23s  apollo11  [wheels]
+            4cc9841  14:27 to 15:11      43m 42s  apollo11  [lens]
+            ce3d2aa  16:29 to 17:06      36m 41s  apollo11  [reactor]
+    \b
+    Tuesday 23 February 2016 (2h 30m 00s)
+            6931d90  12:04 to 12:06      02m 02s  apollo11  [antenna]
+            f0d473c  12:06 to 13:15   1h 08m 32s  apollo11  [antenna]
+            678d9af  13:55 to 14:09      14m 04s  apollo11  [antenna]
+            ae51e4d  14:28 to 14:51      23m 18s  apollo11  [antenna]
+            6fe0aa3  20:26 to 21:01      34m 11s  apollo11  [antenna]
     """  # noqa
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -426,7 +426,7 @@ def report(watson, from_, to, projects, tags, round_to):
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
-@click.option('-r', '--round-to', type=int, default=None,
+@click.option('-r', '--round_to', type=int, default=None,
               help="Rounds daily totals up to the nearest x minutes. "
               "Defaults to no rounding.")
 @click.pass_obj

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -40,9 +40,20 @@ def style(name, element):
 def format_timedelta(delta):
     """
     Return a string roughly representing a timedelta.
+
+    For reference, str(timedelta) returns [x days,] hh:mm:ss
+
     """
     neg = '-' if int(delta.total_seconds()) < 0 else ''
-    res = "{}h {}m {}s".format(*str(abs(delta)).split(":"))
+    fmt = ["{}h ", "{}m ", "{}s"]
+    td = str(abs(delta)).split(":")
+    td[:0] = td.pop(0).split(',')
+    if len(td) == 4:
+        add_hours = int(td.pop(0).split()[0].strip()) * 24
+        td[0] = str(int(td[0]) + add_hours)
+    res = str()
+    for f, k in zip(fmt, td):
+        res += f.format(k.strip()) if int(k) else ''
     return "{}{}".format(neg, res)
 
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -1,8 +1,6 @@
-import itertools
-
 import click
-
 import datetime
+import itertools
 
 from click.exceptions import UsageError
 
@@ -60,20 +58,28 @@ def format_timedelta(delta, round_up_to=0):
     return "{}{}".format(neg, res)
 
 
-def round_time(dt=None, round_up_to=0):
+def round_time(dt, round_up_to=0):
     """
-    Round a datetime object up to nearest round_to minutes
+    Round a datetime object _up_ to nearest round_to minutes.
+
+    First round seconds up or down to the nearest minute, then round that
+    result up to the nearest round_to minute.
 
     Set round_up_to=0 for no rounding
+
     """
-    round_dt = datetime.timedelta(minutes=round_up_to).total_seconds()
-    if dt is None:
-        dt = datetime.now()
     if round_up_to == 0:
         return dt
-    seconds = (dt - dt.min).seconds
+    round_dt = datetime.timedelta(minutes=round_up_to).total_seconds()
+    seconds = int(dt.total_seconds())
+    rounding = (seconds + 60 / 2) // 60 * 60
+    dt += datetime.timedelta(0, rounding - seconds)
+    seconds = int(dt.total_seconds())
     rounding = (seconds + round_dt) // round_dt * round_dt
-    return dt + datetime.timedelta(0, rounding - seconds)
+    if dt.total_seconds() % (round_up_to * 60) != 0:
+        return dt + datetime.timedelta(0, rounding - seconds)
+    else:
+        return dt
 
 
 def sorted_groupby(iterator, key, reverse=False):

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -41,25 +41,9 @@ def format_timedelta(delta):
     """
     Return a string roughly representing a timedelta.
     """
-    seconds = int(delta.total_seconds())
-    neg = seconds < 0
-    seconds = abs(seconds)
-    total = seconds
-    stems = []
-
-    if total >= 3600:
-        hours = seconds // 3600
-        stems.append('{}h'.format(hours))
-        seconds -= hours * 3600
-
-    if total >= 60:
-        mins = seconds // 60
-        stems.append('{:02}m'.format(mins))
-        seconds -= mins * 60
-
-    stems.append('{:02}s'.format(seconds))
-
-    return ('-' if neg else '') + ' '.join(stems)
+    neg = '-' if int(delta.total_seconds()) < 0 else ''
+    res = "{}h {}m {}s".format(*str(abs(delta)).split(":"))
+    return "{}{}".format(neg, res)
 
 
 def sorted_groupby(iterator, key, reverse=False):

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -37,7 +37,7 @@ def style(name, element):
         return fmt(element)
 
 
-def format_timedelta(delta, round_up_to=0):
+def format_timedelta(delta, round_up_to=1):
     """
     Return a string roughly representing a timedelta. Round up to `round_up_to`
     minutes. No rounding by default.
@@ -46,19 +46,23 @@ def format_timedelta(delta, round_up_to=0):
     """
     neg = '-' if int(delta.total_seconds()) < 0 else ''
     delta = round_time(delta, round_up_to)
-    fmt = ["{}h ", "{}m ", "{}s"]
+    fmt = ["{}h ", "{}m", " {}s"]
     td = str(abs(delta)).split(":")
     td[:0] = td.pop(0).split(',')
     if len(td) == 4:
         add_hours = int(td.pop(0).split()[0].strip()) * 24
         td[0] = str(int(td[0]) + add_hours)
+    if round_up_to > 0:
+        # Remove seconds when rounding
+        del fmt[-1]
+        del td[-1]
     res = str()
     for f, k in zip(fmt, td):
-        res += f.format(k.strip()) if int(k) else ''
+        res += f.format(k.strip())
     return "{}{}".format(neg, res)
 
 
-def round_time(dt, round_up_to=0):
+def round_time(dt, round_up_to=1):
     """
     Round a datetime object _up_ to nearest round_to minutes.
 
@@ -90,14 +94,17 @@ def sorted_groupby(iterator, key, reverse=False):
     return itertools.groupby(sorted(iterator, key=key, reverse=reverse), key)
 
 
-def total_by_day(frames, round_to=0, tag=None):
+def total_by_day(frames, round_to=0, tag=None, total=True):
     """
     Given an iterator of Frame objects, return a total result where the time
     for each day is summed and then rounded up to round_to. The rounded totals
     for each day (and for a tag if given) are then summed without rounding and
     returned as the result.
     """
-    frames = list((i for i in frames if not tag or tag in i.tags))
+    if tag == "<untagged>":
+        frames = list((i for i in frames if not i.tags))
+    else:
+        frames = list((i for i in frames if not tag or tag in i.tags))
     days = [list(group) for k, group in
             sorted_groupby(frames,
                            key=lambda x: x.start.datetime.toordinal())]
@@ -106,7 +113,31 @@ def total_by_day(frames, round_to=0, tag=None):
         day_iter = (f.stop - f.start for f in day)
         delta.append(round_time(sum(day_iter, datetime.timedelta()),
                                 round_to))
-    return sum(delta, datetime.timedelta())
+    if total is True:
+        return sum(delta, datetime.timedelta())
+    else:
+        return delta
+
+
+def total_by_each_day(frames, round_to=0, tags=None):
+    """
+    Given an iterator of Frame objects, return a list of
+    [(date, total), (...,.)] where the total for each day is summed (only for
+    'tags' if given) and then rounded up to round_to.
+    """
+    frames = list(i for i in frames if not tags or
+                  (set(i.tags).intersection(set(tags))
+                   or "<untagged>" in tags))
+    days = [list(group) for k, group in
+            sorted_groupby(frames,
+                           key=lambda x: x.start.datetime.toordinal())]
+    delta = []
+    for day in days:
+        day_iter = (f.stop - f.start for f in day)
+        delta.append((day[0].start, round_time(sum(day_iter,
+                                                   datetime.timedelta()),
+                                               round_to)))
+    return delta
 
 
 def options(opt_list):


### PR DESCRIPTION
This PR combines #107 and #108. To summarize:

- Adds ability to round up total work times  in the log and report views. Total work time for each project for each calendar day is summed and rounded up each day, then those values are added for the total time during the report/log period.
- Adds a 'By Date' summary to the report view in addition to the original 'By Tag' view
  - Note: the 'By Tag' view is rounded to the nearest minute regardless of desired rounding. This is due to the rounding differences when rounding all work for one day vs rounding up just the work for one tag during a day. The sum of the 'By Date' hours will be equal to the total value at the top of the report.
  - I added the 'By Date' view to the report because it seems useful to me as a contractor, and because I wanted the sum of the hours to match the total at the top. It made more sense to me to round up total work for the entire day on all tags rather than rounding up each tag each day. I know...it's confusing to read at first!!
- Adds test for format_timedelta and round_time methods
- Changes default report and log rounding to 1 minute (seconds only displayed for each frame in the log view).
- Adds configuration file option for default rounding value

Sorry for the wall of text. Hopefully trying it out and testing the different rounding options will explain it better than my words :smile:

Example report output:

```
$ watson report -f 2016-03-01 --round_to 15
Tue 01 March 2016 -> Thu 10 March 2016

projectname - 5h 30m

        By Tags (unrounded) 
        -------------------
        [tag1         2h 03m]
        [tag2         1h 03m]
        [tag3         1h 28m]
        [tag4         0h 37m]

        By Date
        -------
        [2016-03-04       1h 45m]
        [2016-03-07       0h 30m]
        [2016-03-08       1h 30m]
        [2016-03-10       1h 45m]
```

TODO:

- Add tests for total_by_day and total_by_each_day
- Edit the help text for reports to reflect the new output style
- Squash the commits before merging
