### PR TITLE
[WIP] Add defaults tags for projects

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -149,7 +149,7 @@ same tags are always attached to a particular project.
 
 These automatically attached tags are defined in the `[default_tags]` section
 of the configuration. Each option bellow that section is a project to which
-tags should be attached.
+tags should be attached. The entries should follow the pattern: `project = tag1 tag2`.
 
 You can set default tags for a project from the command line:
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -154,7 +154,7 @@ tags should be attached. The entries should follow the pattern: `project = tag1 
 You can set default tags for a project from the command line:
 
 ```
-$ watson watson config default_tags.python101 'teaching python'
+$ watson config default_tags.python101 'teaching python'
 ```
 
 This corresponds to the following configuration file snippets:

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -148,7 +148,7 @@ Tags can be automatically added for some projects. This is convenient when the
 same tags are always attached to a particular project.
 
 These automatically attached tags are defined in the `[default_tags]` section
-of the configuration. Each option bellow that section is a project to which
+of the configuration. Each option in that section is a project to which
 tags should be attached. The entries should follow the pattern: `project = tag1 tag2`.
 
 You can set default tags for a project from the command line:
@@ -175,7 +175,7 @@ $ watson start python101 +lecture
 Starting project python101 [lecture, teaching, python] at 19:28
 ```
 
-Default tags can contain space characters when wrote in between quotes:
+Default tags can contain space characters when written in between quotes:
 
 ```
 $ watson config default_tags.voyager2 'nasa "space mission"'

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -144,8 +144,8 @@ Globally configure how `time` should be formatted. All [python's `strftime` dire
 
 ### Default tags
 
-Tags can be automatically added for some projects. This is convenient when the
-same tags are always attached to a particular project.
+Tags can be automatically added for selected projects. This is convenient when
+the same tags are always attached to a particular project.
 
 These automatically attached tags are defined in the `[default_tags]` section
 of the configuration. Each option in that section is a project to which

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -142,6 +142,52 @@ Globally configure how `dates` should be formatted. All [python's `strftime` dir
 
 Globally configure how `time` should be formatted. All [python's `strftime` directives](http://strftime.org) are supported.
 
+### Default tags
+
+Tags can be automatically added for some projects. This is convenient when the
+same tags are always attached to a project.
+
+These automatically attached tags are defined in the `[default_tags]` section
+of the configuration. Each option bellow that section is a project to which
+tags should be attached.
+
+You can set default tags for a project from the command line:
+
+```
+$ watson watson config default_tags.python101 'teaching python'
+```
+
+This corresponds to the following configuration file snippets:
+
+```ini
+[default_tags]
+python101 = teaching python
+```
+
+With these default tags set, the tags "teaching" and "python" will
+automatically be attached to the project "python101":
+
+```
+$ watson start python101
+Starting project python101 [teaching, python] at 19:27
+
+$ watson start python101 +lecture
+Starting project python101 [lecture, teaching, python] at 19:28
+```
+
+Default tags can contain space characters when wrote in between quotes:
+
+```
+$ watson watson config default_tags.voyager2 'nasa "space mission"'
+```
+
+Or in the configuration file:
+
+```ini
+[default_tags]
+voyager2 = nana 'space mission'
+```
+
 ## Sample configuration file
 
 A basic configuration file looks like the following:

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -145,7 +145,7 @@ Globally configure how `time` should be formatted. All [python's `strftime` dire
 ### Default tags
 
 Tags can be automatically added for some projects. This is convenient when the
-same tags are always attached to a project.
+same tags are always attached to a particular project.
 
 These automatically attached tags are defined in the `[default_tags]` section
 of the configuration. Each option bellow that section is a project to which
@@ -178,14 +178,14 @@ Starting project python101 [lecture, teaching, python] at 19:28
 Default tags can contain space characters when wrote in between quotes:
 
 ```
-$ watson watson config default_tags.voyager2 'nasa "space mission"'
+$ watson config default_tags.voyager2 'nasa "space mission"'
 ```
 
 Or in the configuration file:
 
 ```ini
 [default_tags]
-voyager2 = nana 'space mission'
+voyager2 = nasa 'space mission'
 ```
 
 ## Sample configuration file

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -466,7 +466,7 @@ my project = A B
         assert watson.current['tags'] == ['A', 'B']
 
 
-def test_start_default_tags_with_tags(watson):
+def test_start_default_tags_with_supplementary_input_tags(watson):
     content = u"""
 [default_tags]
 my project = A B

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -407,6 +407,21 @@ def test_set_config(watson):
     watson.config.get('foo', 'bar') == 'lol'
 
 
+def test_get_default_tags(watson):
+    content = u"""
+[default_tags]
+single = tag1
+multiple = tag1 tag2 tag3
+spaces = tag1 'with space'
+    """
+
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        assert watson._default_tags('single') == ['tag1']
+        assert watson._default_tags('multiple') == ['tag1', 'tag2', 'tag3']
+        assert watson._default_tags('spaces') == ['tag1', 'with space']
+        assert watson._default_tags('non defined') == []
+
+
 # start
 
 def test_start_new_project(watson):
@@ -438,6 +453,28 @@ def test_start_two_projects(watson):
     assert watson.current != {}
     assert watson.current['project'] == 'foo'
     assert watson.is_started is True
+
+
+def test_start_default_tags(watson):
+    content = u"""
+[default_tags]
+my project = A B
+    """
+
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        watson.start('my project')
+        assert watson.current['tags'] == ['A', 'B']
+
+
+def test_start_default_tags_with_tags(watson):
+    content = u"""
+[default_tags]
+my project = A B
+    """
+
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        watson.start('my project', tags=['C', 'D'])
+        assert watson.current['tags'] == ['C', 'D', 'A', 'B']
 
 
 # stop

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -407,21 +407,6 @@ def test_set_config(watson):
     watson.config.get('foo', 'bar') == 'lol'
 
 
-def test_get_default_tags(watson):
-    content = u"""
-[default_tags]
-single = tag1
-multiple = tag1 tag2 tag3
-spaces = tag1 'with space'
-    """
-
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        assert watson._default_tags('single') == ['tag1']
-        assert watson._default_tags('multiple') == ['tag1', 'tag2', 'tag3']
-        assert watson._default_tags('spaces') == ['tag1', 'with space']
-        assert watson._default_tags('non defined') == []
-
-
 # start
 
 def test_start_new_project(watson):

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -106,7 +106,7 @@ def _start(watson, project, tags):
     current = watson.start(project, tags)
     click.echo("Starting project {} {} at {}".format(
         style('project', project),
-        style('tags', tags),
+        style('tags', current['tags']),
         style('time', "{:HH:mm}".format(current['start']))
     ))
     watson.save()

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -99,11 +99,11 @@ def help(ctx, command):
     click.echo(cmd.get_help(ctx))
 
 
-def _start(watson, project, tags):
+def _start(watson, project, tags, restart=False):
     """
     Start project with given list of tags and save status.
     """
-    current = watson.start(project, tags)
+    current = watson.start(project, tags, restart=restart)
     click.echo("Starting project {} {} at {}".format(
         style('project', project),
         style('tags', current['tags']),
@@ -230,7 +230,7 @@ def restart(ctx, watson, frame, stop_):
 
     frame = get_frame_from_argument(watson, frame)
 
-    _start(watson, frame.project, frame.tags)
+    _start(watson, frame.project, frame.tags, restart=True)
 
 
 @cli.command()

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -197,3 +197,12 @@ def safe_save(path, content, ext='.bak'):
             os.rename(path, path + ext)
 
         os.rename(tmpfp.name, path)
+
+
+def deduplicate(sequence):
+    """
+    Return the input sequence without duplicate, keep the order.
+    """
+    return [element
+            for index, element in enumerate(sequence)
+            if element not in sequence[:index]]

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -248,7 +248,6 @@ class Watson(object):
         default_tags = self.config.getlist('default_tags', project)
         if not restart:
             tags = (tags or []) + default_tags
-            print(deduplicate(tags))
 
         self.current = {'project': project, 'tags': deduplicate(tags)}
         return self.current

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -2,6 +2,7 @@
 
 import os
 import json
+import shlex
 
 try:
     import configparser
@@ -436,5 +437,5 @@ class Watson(object):
         if default_tags_raw is None:
             default_tags = []
         else:
-            default_tags = default_tags_raw.split()
+            default_tags = shlex.split(default_tags_raw)
         return default_tags

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -251,7 +251,7 @@ class Watson(object):
                 tags = default_tags
             else:
                 tags = tags + default_tags
-            
+
         self.current = {'project': project, 'tags': tags}
         return self.current
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -245,6 +245,13 @@ class Watson(object):
                 )
             )
 
+        default_tags = self._default_tags(project)
+        if default_tags:
+            if tags is None:
+                tags = default_tags
+            else:
+                tags = tags + default_tags
+            
         self.current = {'project': project, 'tags': tags}
         return self.current
 
@@ -423,3 +430,11 @@ class Watson(object):
                 merging.append(conflict_frame)
 
         return conflicting, merging
+
+    def _default_tags(self, project):
+        default_tags_raw = self.config.get('default_tags', project)
+        if default_tags_raw is None:
+            default_tags = []
+        else:
+            default_tags = default_tags_raw.split()
+        return default_tags

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -14,7 +14,7 @@ import requests
 
 from .config import ConfigParser
 from .frames import Frames
-from .utils import make_json_writer, safe_save, deduplicate
+from .utils import deduplicate, make_json_writer, safe_save
 from .version import version as __version__  # noqa
 
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -434,8 +434,7 @@ class Watson(object):
 
     def _default_tags(self, project):
         default_tags_raw = self.config.get('default_tags', project)
-        if default_tags_raw is None:
-            default_tags = []
-        else:
+        default_tags = []
+        if default_tags_raw is not None:
             default_tags = shlex.split(default_tags_raw)
         return default_tags

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -2,7 +2,6 @@
 
 import os
 import json
-import shlex
 
 try:
     import configparser

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -235,7 +235,7 @@ class Watson(object):
     def is_started(self):
         return bool(self.current)
 
-    def start(self, project, tags=None):
+    def start(self, project, tags=None, restart=False):
         if not project:
             raise WatsonError("No project given.")
 
@@ -247,7 +247,7 @@ class Watson(object):
             )
 
         default_tags = self._default_tags(project)
-        if default_tags:
+        if default_tags and not restart:
             if tags is None:
                 tags = default_tags
             else:


### PR DESCRIPTION
Some projects are always used with the same tags. For instance, my
'python101' project should always have the 'teaching' tag attached to
it.

This commit adds a way to declare such default tags in the configuration
file, and have them applied. Default tags are expected to be declared in
a '[default_tags]' section:

    [default_tags]
    python101 = teaching
    watson = contrib python

With the sample configuration above, the 'teaching' tag will always be
attached to the 'python101' project, and the tags 'contrib' and 'python'
will always be attached to the project 'watson'.

Projects that do not appear in the '[default_tags]' section of the
configuration will not be affected by the change.

Note that the tags added by the new mechanism do not show in the output
of `watson start`. However, they appear in the output of `watson
status`, `watson log`, and of course `watson report`.

This pull request is still a work in progress. It still requires at least:
* [x] to update the documentation
* [x] to be properly tested