### PR TITLE
Add new method 'getlist' to 'ConfigParser'

### DIFF
--- a/watson/config.py
+++ b/watson/config.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """A convenience and compatibility wrapper for RawConfigParser."""
 
+import shlex
+
 try:
     from configparser import RawConfigParser
 except ImportError:
@@ -59,6 +61,43 @@ class ConfigParser(RawConfigParser):
         """
         val = self.get(section, option)
         return val.lower() in ('1', 'on', 'true', 'yes') if val else default
+
+    def getlist(self, section, option, default=None):
+        """
+        Return value of option in given section as a list of strings.
+
+        If option is not set, return default (defaults to an empty list).
+
+        The option value is split into list tokens using one of two strategies:
+
+        * If the value contains any newlines, i.e. it was written in the
+          configuration file using continuation lines, the value is split at
+          newlines and empty items are discarded.
+        * Otherwise, the value is split according to unix shell parsing rules.
+          Items are separated by whitespace, but items can be enclosed in
+          single or double quotes to preserve spaces in them.
+
+        Example::
+
+            [test]
+            option2 =
+                one
+                two three
+                four
+                sive six
+            option1 = one  "two three" four 'five  six'
+
+        """
+        if not self.has_option(section, option):
+            return [] if default is None else default
+
+        value = self.get(section, option)
+
+        if '\n' in value:
+            return [item.strip()
+                    for item in value.splitlines() if item.strip()]
+        else:
+            return shlex.split(value)
 
     def set(self, section, option, value):
         """


### PR DESCRIPTION
This allows to get a configuration value as a list of strings.

For now this mainly to support PR #113, but could be used by future new features as well.

Here's a copy of the included docstring:

```
Return value of option in given section as a list of strings.

If option is not set, return default (defaults to an empty list).

The option value is split into list tokens using one of two strategies:

* If the value contains any newlines, i.e. it was written in the
  configuration file using continuation lines, the value is split at
  newlines and empty items are discarded.
* Otherwise, the value is split according to unix shell parsing rules.
  Items are separated by whitespace, but items can be enclosed in 
  single or double quotes to preserve spaces in them.
  
Example::

    [test]
    option2 =
        one
        two three
        four
        sive six
    option1 = one  "two three" four 'five  six'
```