### PR TITLE
Handle errors when saving files gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ This document records all notable changes to Watson. This project adheres to
   timespan to the current year, month, week or day.
 * Added: Zsh completion support
 * Added: document installation via homebrew on OS X
+* Updated: when saving the Watson frames, state or config file, the most recent
+  previous version of the file is kept as a back up.
 * Fixed: bash completion of projects and tags with spaces in them
+* Fixed: if saving the Watson frames, state or config file fails for any
+  reason, the original is kept (and not wiped as before).
 
 ## 1.3.2 (2016-03-01)
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -14,6 +14,7 @@ import requests
 
 from .config import ConfigParser
 from .frames import Frames
+from .utils import make_json_writer, safe_save
 from .version import version as __version__  # noqa
 
 
@@ -21,7 +22,7 @@ class WatsonError(RuntimeError):
     pass
 
 
-class ConfigurationError(WatsonError, configparser.Error):
+class ConfigurationError(configparser.Error, WatsonError):
     pass
 
 
@@ -147,21 +148,18 @@ class Watson(object):
                 else:
                     current = {}
 
-                with open(self.state_file, 'w+') as f:
-                    json.dump(current, f, indent=1, ensure_ascii=False)
+                safe_save(self.state_file, make_json_writer(lambda: current))
 
             if self._frames is not None and self._frames.changed:
-                with open(self.frames_file, 'w+') as f:
-                    json.dump(self.frames.dump(), f, indent=1,
-                              ensure_ascii=False)
+                safe_save(self.frames_file,
+                          make_json_writer(self.frames.dump))
 
             if self._config_changed:
-                with open(self.config_file, 'w+') as f:
-                    self.config.write(f)
+                safe_save(self.config_file, self.config.write)
 
             if self._last_sync is not None:
-                with open(self.last_sync_file, 'w+') as f:
-                    json.dump(self._format_date(self.last_sync), f)
+                safe_save(self.last_sync_file,
+                          make_json_writer(self._format_date, self.last_sync))
         except OSError as e:
             raise WatsonError(
                 "Impossible to write {}: {}".format(e.filename, e)


### PR DESCRIPTION
Fixes #118.

* Prevent existing files from being wiped when writing fails
* Backup previous file if it exists when writing succeeds

To fix test failures with python 2.7 I had to change the imports at the top of the tests so that the test under Python 2.7 always use `StringIO.StringIO` instead of `io.StringIO`. The latter doesn't cooperate with `json.dump` under Python 2.7.