### PR TITLE
Add command line and config file options to log and report commands to include currently running frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This document records all notable changes to Watson. This project adheres to
 ## Development
 
 * Added: Watson now has a `rename` command.
-* Added: the `report` and `log` commands now have new options to set the 
+* Added: the `report` and `log` commands now have new command line and
+  config file options to (not) include the current frame in the output.
+* Added: the `report` and `log` commands now have new options to set the
   timespan to the current year, month, week or day.
 * Added: Zsh completion support
 * Added: document installation via homebrew on OS X

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -162,6 +162,7 @@ Example:
 
 Flag | Help
 -----|-----
+`-c, --current / -C, --no-current` | (Don't) include currently running frame in output.
 `-f, --from DATE` | The date from when the log should start. Defaults to seven days ago.
 `-t, --to DATE` | The date at which the log should stop (inclusive). Defaults to tomorrow.
 `-y, --year` | Reports activity for the current year.
@@ -309,9 +310,8 @@ Usage:  watson report [OPTIONS]
 
 Display a report of the time spent on each project.
 
-If a project is given, the time spent on this project
-is printed. Else, print the total for each root
-project.
+If a project is given, the time spent on this project is printed.
+Else, print the total for each root project.
 
 By default, the time spent the last 7 days is printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
@@ -372,6 +372,7 @@ Example:
 
 Flag | Help
 -----|-----
+`-c, --current / -C, --no-current` | (Don't) include currently running frame in report.
 `-f, --from DATE` | The date from when the report should start. Defaults to seven days ago.
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
 `-y, --year` | Reports activity for the current year.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -98,6 +98,18 @@ To authenticate watson as an API client, once generated, you will need to set up
 
 ### Options
 
+#### `options.log_current`
+
+If `true`, the output of the `log` command will include the currently running
+frame (if any) by default. The option can be overridden on the command line
+with the `-c/-C` resp. `--current/--no-current` flags.
+
+#### `options.log_current`
+
+If `true`, the output of the `report` command will include the currently
+running frame (if any) by default. The option can be overridden on the
+command line with the `-c/-C` resp. `--current/--no-current` flags.
+
 #### `options.stop_on_start`
 
 If `true`, starting a new project will stop running projects:
@@ -146,6 +158,8 @@ stop_on_start = true
 stop_on_restart = false
 date_format = '%Y.%m.%d'
 time_format = '%H:%M:%S%z'
+log_current = false
+report_current = false
 ```
 
 ## Application folder

--- a/watson.completion
+++ b/watson.completion
@@ -35,7 +35,7 @@ _watson_complete () {
               COMPREPLY=($(compgen -W "$tags" -- ${cur}))
               ;;
             *)
-              COMPREPLY=($(compgen -W "-f -t -p -T --from --to --project --tag" -- ${cur})) ;;
+              COMPREPLY=($(compgen -W "-c -C -f -p -t -T --current --no-current --from --to --project --tag" -- ${cur})) ;;
           esac
           ;;
         merge)


### PR DESCRIPTION
Also add config file option for adding current frame to log/report output by default.

Fixes #31.