### PR TITLE
Timespan shortcuts (report/log commands)

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -120,6 +120,10 @@ By default, the sessions from the last 7 days are printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
 must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
+Also you can use a special shortcuts for easily timespan control: `--day` is
+for the last day activity and `--year`/`--month`/`--week` for an activity
+during the current year/month/week correspondingly.
+
 You can limit the log to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the log.
@@ -159,6 +163,10 @@ Flag | Help
 -----|-----
 `-f, --from DATE` | The date from when the log should start. Defaults to seven days ago.
 `-t, --to DATE` | The date at which the log should stop (inclusive). Defaults to tomorrow.
+`-y, --year` | Reports activity for the current year.
+`-m, --month` | Reports activity for the current month.
+`-w, --week` | Reports activity for the current week.
+`-d, --day` | Reports activity for the last day.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `--help` | Show this message and exit.
@@ -286,6 +294,10 @@ By default, the time spent the last 7 days is printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
 must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
+Also you can use a special shortcuts for easily timespan control: `--day` is
+for the last day activity and `--year`/`--month`/`--week` for an activity
+during the current year/month/week correspondingly.
+
 You can limit the report to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the report.
@@ -338,6 +350,10 @@ Flag | Help
 -----|-----
 `-f, --from DATE` | The date from when the report should start. Defaults to seven days ago.
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
+`-y, --year` | Reports activity for the current year.
+`-m, --month` | Reports activity for the current month.
+`-w, --week` | Reports activity for the current week.
+`-d, --day` | Reports activity for the last day.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `--help` | Show this message and exit.

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -23,7 +23,7 @@ from dateutil.tz.tz import tzutc
 from click import get_app_dir
 from watson import Watson, WatsonError
 from watson.watson import ConfigurationError, ConfigParser
-from watson.utils import get_beginning_arrow
+from watson.utils import get_start_time_for_period
 
 TEST_FIXTURE_DIR = py.path.local(
     os.path.dirname(
@@ -820,7 +820,7 @@ _dt = datetime.datetime
 _tz = {'tzinfo': tzutc()}
 
 
-@pytest.mark.parametrize('now, mode, beginning', [
+@pytest.mark.parametrize('now, mode, start_time', [
     (_dt(2016, 6, 2, **_tz), 'year', _dt(2016, 1, 1, **_tz)),
     (_dt(2016, 6, 2, **_tz), 'month', _dt(2016, 6, 1, **_tz)),
     (_dt(2016, 6, 2, **_tz), 'week', _dt(2016, 5, 30, **_tz)),
@@ -831,6 +831,6 @@ _tz = {'tzinfo': tzutc()}
     (_dt(2012, 2, 24, **_tz), 'week', _dt(2012, 2, 20, **_tz)),
     (_dt(2012, 2, 24, **_tz), 'day', _dt(2012, 2, 24, **_tz)),
 ])
-def test_get_beginning_arrow(now, mode, beginning):
+def test_get_start_time_arrow(now, mode, start_time):
     with mock_datetime(now, datetime):
-        assert get_beginning_arrow(mode).datetime == beginning
+        assert get_start_time_for_period(mode).datetime == start_time

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -824,10 +824,12 @@ _tz = {'tzinfo': tzutc()}
     (_dt(2016, 6, 2, **_tz), 'year', _dt(2016, 1, 1, **_tz)),
     (_dt(2016, 6, 2, **_tz), 'month', _dt(2016, 6, 1, **_tz)),
     (_dt(2016, 6, 2, **_tz), 'week', _dt(2016, 5, 30, **_tz)),
+    (_dt(2016, 6, 2, **_tz), 'day', _dt(2016, 6, 2, **_tz)),
 
     (_dt(2012, 2, 24, **_tz), 'year', _dt(2012, 1, 1, **_tz)),
     (_dt(2012, 2, 24, **_tz), 'month', _dt(2012, 2, 1, **_tz)),
     (_dt(2012, 2, 24, **_tz), 'week', _dt(2012, 2, 20, **_tz)),
+    (_dt(2012, 2, 24, **_tz), 'day', _dt(2012, 2, 24, **_tz)),
 ])
 def test_get_beginning_arrow(now, mode, beginning):
     with mock_datetime(now, datetime):

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import os
+import datetime
 
 try:
     from unittest import mock
@@ -17,9 +18,12 @@ import pytest
 import requests
 import arrow
 
+from dateutil.tz.tz import tzutc
+
 from click import get_app_dir
 from watson import Watson, WatsonError
 from watson.watson import ConfigurationError, ConfigParser
+from watson.utils import get_beginning_arrow
 
 TEST_FIXTURE_DIR = py.path.local(
     os.path.dirname(
@@ -33,6 +37,33 @@ if not PY2:
     builtins = 'builtins'
 else:
     builtins = '__builtin__'
+
+
+def mock_datetime(dt, dt_module):
+
+    class DateTimeMeta(type):
+
+        @classmethod
+        def __instancecheck__(mcs, obj):
+            return isinstance(obj, datetime.datetime)
+
+    class BaseMockedDateTime(datetime.datetime):
+
+        @classmethod
+        def now(cls, tz=None):
+            return dt.replace(tzinfo=tz)
+
+        @classmethod
+        def utcnow(cls):
+            return dt
+
+        @classmethod
+        def today(cls):
+            return dt
+
+    MockedDateTime = DateTimeMeta('datetime', (BaseMockedDateTime,), {})
+
+    return mock.patch.object(dt_module, 'datetime', MockedDateTime)
 
 
 @pytest.fixture
@@ -781,3 +812,22 @@ def test_merge_report(watson, datafiles):
 
     assert conflicting[0].id == '2'
     assert merging[0].id == '3'
+
+
+# report/log
+
+_dt = datetime.datetime
+_tz = {'tzinfo': tzutc()}
+
+@pytest.mark.parametrize('now, mode, beginning', [
+    (_dt(2016, 6, 2, **_tz), 'year', _dt(2016, 1, 1, **_tz)),
+    (_dt(2016, 6, 2, **_tz), 'month', _dt(2016, 6, 1, **_tz)),
+    (_dt(2016, 6, 2, **_tz), 'week', _dt(2016, 5, 30, **_tz)),
+
+    (_dt(2012, 2, 24, **_tz), 'year', _dt(2012, 1, 1, **_tz)),
+    (_dt(2012, 2, 24, **_tz), 'month', _dt(2012, 2, 1, **_tz)),
+    (_dt(2012, 2, 24, **_tz), 'week', _dt(2012, 2, 20, **_tz)),
+])
+def test_get_beginning_arrow(now, mode, beginning):
+    with mock_datetime(now, datetime):
+        assert get_beginning_arrow(mode).datetime == beginning

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -819,6 +819,7 @@ def test_merge_report(watson, datafiles):
 _dt = datetime.datetime
 _tz = {'tzinfo': tzutc()}
 
+
 @pytest.mark.parametrize('now, mode, beginning', [
     (_dt(2016, 6, 2, **_tz), 'year', _dt(2016, 1, 1, **_tz)),
     (_dt(2016, 6, 2, **_tz), 'month', _dt(2016, 6, 1, **_tz)),

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -15,7 +15,7 @@ import click
 from . import watson
 from .frames import Frame
 from .utils import (format_timedelta, get_frame_from_argument, options,
-                    sorted_groupby, style, get_beginning_arrow)
+                    sorted_groupby, style, get_start_time_for_period)
 
 
 class MutuallyExclusiveOption(click.Option):
@@ -300,19 +300,19 @@ _SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
               help="The date at which the report should stop (inclusive). "
               "Defaults to tomorrow.")
 @click.option('-y', '--year', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('year'),
+              flag_value=get_start_time_for_period('year'),
               mutually_exclusive=['day', 'week', 'month'],
               help='Reports activity for the current year.')
 @click.option('-m', '--month', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('month'),
+              flag_value=get_start_time_for_period('month'),
               mutually_exclusive=['day', 'week', 'year'],
               help='Reports activity for the current month.')
 @click.option('-w', '--week', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('week'),
+              flag_value=get_start_time_for_period('week'),
               mutually_exclusive=['day', 'month', 'year'],
               help='Reports activity for the current week.')
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('day'),
+              flag_value=get_start_time_for_period('day'),
               mutually_exclusive=['week', 'month', 'year'],
               help='Reports activity for the current day.')
 @click.option('-p', '--project', 'projects', multiple=True,
@@ -386,9 +386,9 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
     """
-    for shortcut_arrow in (_ for _ in [day, week, month, year]
-                           if _ is not None):
-        from_ = shortcut_arrow
+    for start_time in (_ for _ in [day, week, month, year]
+                       if _ is not None):
+        from_ = start_time
 
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
@@ -459,19 +459,19 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
               help="The date at which the log should stop (inclusive). "
               "Defaults to tomorrow.")
 @click.option('-y', '--year', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('year'),
+              flag_value=get_start_time_for_period('year'),
               mutually_exclusive=['day', 'week', 'month'],
               help='Reports activity for the current year.')
 @click.option('-m', '--month', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('month'),
+              flag_value=get_start_time_for_period('month'),
               mutually_exclusive=['day', 'week', 'year'],
               help='Reports activity for the current month.')
 @click.option('-w', '--week', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('week'),
+              flag_value=get_start_time_for_period('week'),
               mutually_exclusive=['day', 'month', 'year'],
               help='Reports activity for the current week.')
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=get_beginning_arrow('day'),
+              flag_value=get_start_time_for_period('day'),
               mutually_exclusive=['week', 'month', 'year'],
               help='Reports activity for the current day.')
 @click.option('-p', '--project', 'projects', multiple=True,
@@ -528,9 +528,9 @@ def log(watson, from_, to, projects, tags, year, month, week, day):
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
     """  # noqa
-    for shortcut_arrow in (_ for _ in [day, week, month, year]
-                           if _ is not None):
-        from_ = shortcut_arrow
+    for start_time in (_ for _ in [day, week, month, year]
+                       if _ is not None):
+        from_ = start_time
 
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -385,9 +385,9 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
     """
-    for shortcut_timestamp in (_ for _ in [day, week, month, year]
-                               if _ is not None):
-        from_ = shortcut_timestamp
+    for shortcut_arrow in (_ for _ in [day, week, month, year]
+                           if _ is not None):
+        from_ = shortcut_arrow
 
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
@@ -526,9 +526,9 @@ def log(watson, from_, to, projects, tags, year, month, week, day):
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
     """  # noqa
-    for shortcut_timestamp in (_ for _ in [day, week, month, year]
-                               if _ is not None):
-        from_ = shortcut_timestamp
+    for shortcut_arrow in (_ for _ in [day, week, month, year]
+                           if _ is not None):
+        from_ = shortcut_arrow
 
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -335,7 +335,7 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
-    Also you can use a special shortcuts for easily timespan control: `--day`
+    Also you can use a special shortcuts for easy timespan control: `--day`
     is for the last 24 hours activity and `--year`/`--month`/`--week` for an
     activity during the current year/month/week correspondingly.
 
@@ -489,7 +489,7 @@ def log(watson, from_, to, projects, tags, year, month, week, day):
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
-    Also you can use a special shortcuts for easily timespan control: `--day`
+    Also you can use a special shortcuts for easy timespan control: `--day`
     is for the last 24 hours activity and `--year`/`--month`/`--week` for an
     activity during the current year/month/week correspondingly.
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -31,7 +31,7 @@ class MutuallyExclusiveOption(click.Option):
                                    options=', '
                                    .join(['`--{}`'.format(_) for _ in
                                          self.mutually_exclusive]))
-        )
+            )
 
         return super(MutuallyExclusiveOption, self).handle_parse_result(
             ctx, opts, args
@@ -287,6 +287,7 @@ def status(watson):
 
 _SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
 
+
 @cli.command()
 @click.option('-f', '--from', 'from_', cls=MutuallyExclusiveOption, type=Date,
               default=arrow.now().replace(days=-7),
@@ -334,9 +335,9 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
-    Also you can use a special shortcuts for easily timespan control: `--day` is
-    for the last day activity and `--year`/`--month`/`--week` for an activity
-    during the current year/month/week correspondingly.
+    Also you can use a special shortcuts for easily timespan control: `--day`
+    is for the last day activity and `--year`/`--month`/`--week` for an
+    activity during the current year/month/week correspondingly.
 
     You can limit the report to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
@@ -488,9 +489,9 @@ def log(watson, from_, to, projects, tags, year, month, week, day):
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
-    Also you can use a special shortcuts for easily timespan control: `--day` is
-    for the last day activity and `--year`/`--month`/`--week` for an activity
-    during the current year/month/week correspondingly.
+    Also you can use a special shortcuts for easily timespan control: `--day`
+    is for the last day activity and `--year`/`--month`/`--week` for an
+    activity during the current year/month/week correspondingly.
 
     You can limit the log to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -314,7 +314,7 @@ _SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
               flag_value=arrow.now().replace(hours=-24),
               mutually_exclusive=['week', 'month', 'year'],
-              help='Reports activity for the last day.')
+              help='Reports activity for the last 24 hours.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Reports activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -336,7 +336,7 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
     Also you can use a special shortcuts for easily timespan control: `--day`
-    is for the last day activity and `--year`/`--month`/`--week` for an
+    is for the last 24 hours activity and `--year`/`--month`/`--week` for an
     activity during the current year/month/week correspondingly.
 
     You can limit the report to a project or a tag using the `--project` and
@@ -472,7 +472,7 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
               flag_value=arrow.now().replace(hours=-24),
               mutually_exclusive=['week', 'month', 'year'],
-              help='Reports activity for the last day.')
+              help='Reports activity for the last 24 hours.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Logs activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -490,7 +490,7 @@ def log(watson, from_, to, projects, tags, year, month, week, day):
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
     Also you can use a special shortcuts for easily timespan control: `--day`
-    is for the last day activity and `--year`/`--month`/`--week` for an
+    is for the last 24 hours activity and `--year`/`--month`/`--week` for an
     activity during the current year/month/week correspondingly.
 
     You can limit the log to a project or a tag using the `--project` and

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -335,7 +335,7 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
-    Also you can use a special shortcuts for easy timespan control: `--day`
+    Also you can use special shortcuts for easy timespan control: `--day`
     is for the current day's activity (beginning from 00:00) and
     `--year`/`--month`/`--week` for an activity during the current
     year/month/week correspondingly.
@@ -490,7 +490,7 @@ def log(watson, from_, to, projects, tags, year, month, week, day):
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
-    Also you can use a special shortcuts for easy timespan control: `--day`
+    Also you can use special shortcuts for easy timespan control: `--day`
     is for the current day's activity (beginning from 00:00) and
     `--year`/`--month`/`--week` for an activity during the current
     year/month/week correspondingly.

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -312,9 +312,9 @@ _SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
               mutually_exclusive=['day', 'month', 'year'],
               help='Reports activity for the current week.')
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=arrow.now().replace(hours=-24),
+              flag_value=get_beginning_arrow('day'),
               mutually_exclusive=['week', 'month', 'year'],
-              help='Reports activity for the last 24 hours.')
+              help='Reports activity for the current day.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Reports activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -336,8 +336,9 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
     Also you can use a special shortcuts for easy timespan control: `--day`
-    is for the last 24 hours activity and `--year`/`--month`/`--week` for an
-    activity during the current year/month/week correspondingly.
+    is for the current day's activity (beginning from 00:00) and
+    `--year`/`--month`/`--week` for an activity during the current
+    year/month/week correspondingly.
 
     You can limit the report to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
@@ -470,9 +471,9 @@ def report(watson, from_, to, projects, tags, year, month, week, day):
               mutually_exclusive=['day', 'month', 'year'],
               help='Reports activity for the current week.')
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
-              flag_value=arrow.now().replace(hours=-24),
+              flag_value=get_beginning_arrow('day'),
               mutually_exclusive=['week', 'month', 'year'],
-              help='Reports activity for the last 24 hours.')
+              help='Reports activity for the current day.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Logs activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -490,8 +491,9 @@ def log(watson, from_, to, projects, tags, year, month, week, day):
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
     Also you can use a special shortcuts for easy timespan control: `--day`
-    is for the last 24 hours activity and `--year`/`--month`/`--week` for an
-    activity during the current year/month/week correspondingly.
+    is for the current day's activity (beginning from 00:00) and
+    `--year`/`--month`/`--week` for an activity during the current
+    year/month/week correspondingly.
 
     You can limit the log to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -120,12 +120,15 @@ def get_beginning_arrow(shortcut):
     now = arrow.Arrow.fromdatetime(datetime.datetime.now())
     date = now.date()
 
+    day = date.day
     month = date.month
     year = date.year
 
     weekday = now.weekday()
 
-    if shortcut == 'week':
+    if shortcut == 'day':
+        arw = arrow.Arrow(year, month, day)
+    elif shortcut == 'week':
         arw = arrow.Arrow.fromdate(now.replace(days=-weekday).date())
     elif shortcut == 'month':
         arw = arrow.Arrow(year, month, 1)

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -115,7 +115,7 @@ def get_frame_from_argument(watson, arg):
         )
 
 
-def get_beginning_arrow(shortcut):
+def get_start_time_for_period(period):
     # Using now() from datetime instead of arrow for mocking compatibility.
     now = arrow.Arrow.fromdatetime(datetime.datetime.now())
     date = now.date()
@@ -126,15 +126,15 @@ def get_beginning_arrow(shortcut):
 
     weekday = now.weekday()
 
-    if shortcut == 'day':
-        arw = arrow.Arrow(year, month, day)
-    elif shortcut == 'week':
-        arw = arrow.Arrow.fromdate(now.replace(days=-weekday).date())
-    elif shortcut == 'month':
-        arw = arrow.Arrow(year, month, 1)
-    elif shortcut == 'year':
-        arw = arrow.Arrow(year, 1, 1)
+    if period == 'day':
+        start_time = arrow.Arrow(year, month, day)
+    elif period == 'week':
+        start_time = arrow.Arrow.fromdate(now.replace(days=-weekday).date())
+    elif period == 'month':
+        start_time = arrow.Arrow(year, month, 1)
+    elif period == 'year':
+        start_time = arrow.Arrow(year, 1, 1)
     else:
-        raise ValueError('Unsupported shortcut value: {}'.format(shortcut))
+        raise ValueError('Unsupported period value: {}'.format(period))
 
-    return arw
+    return start_time

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -1,6 +1,8 @@
 import itertools
+import datetime
 
 import click
+import arrow
 
 from click.exceptions import UsageError
 
@@ -111,3 +113,25 @@ def get_frame_from_argument(watson, arg):
             style('error', "No frame found with id"),
             style('short_id', arg))
         )
+
+
+def get_beginning_arrow(shortcut):
+    # Using now() from datetime instead of arrow for mocking compatibility.
+    now = arrow.Arrow.fromdatetime(datetime.datetime.now())
+    date = now.date()
+
+    month = date.month
+    year = date.year
+
+    weekday = now.weekday()
+
+    if shortcut == 'week':
+        arw = arrow.Arrow.fromdate(now.replace(days=-weekday).date())
+    elif shortcut == 'month':
+        arw = arrow.Arrow(year, month, 1)
+    elif shortcut == 'year':
+        arw = arrow.Arrow(year, 1, 1)
+    else:
+        raise ValueError('Unsupported shortcut value: {}'.format(shortcut))
+
+    return arw


### PR DESCRIPTION
Add a humanized shortcut-options to the `watson report` and `watson log` commands for an easily timespan control for common usage cases (e.g., how much time I spent over my project during last month, etc?) without precise `--from`/`--to` syntax.

Example:
```
(.env) Luna:Watson alexkey$ watson report --year
Fri 01 January 2016 -> Mon 13 June 2016

<...>

(.env) Luna:Watson alexkey$ watson report --month
Wed 01 June 2016 -> Mon 13 June 2016

<...>

(.env) Luna:Watson alexkey$ watson report --week
Mon 13 June 2016 -> Mon 13 June 2016

<...>

(.env) Luna:Watson alexkey$ watson report --day
Sun 12 June 2016 -> Mon 13 June 2016

<...>
```