### PR TITLE
Provide make facility for dev env creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules/
 .tox
 dist/
 site/
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,49 @@
 # Watson
 
+PYTHON ?= python
+PIP ?= pip
+
+VENV = virtualenv
+VENV_ARGS = -p $(PYTHON)
+VENV_DIR = $(CURDIR)/.venv
+
 all: install
 
+$(VENV_DIR): requirements-dev.txt
+	$(VENV) $(VENV_ARGS) "$(VENV_DIR)"
+	"$(VENV_DIR)"/bin/pip install -U setuptools wheel pip
+	"$(VENV_DIR)"/bin/pip install -Ur $<
+
+.PHONY: env
+env: $(VENV_DIR)
+
+.PHONY: install
 install:
-	python setup.py install
+	$(PYTHON) setup.py install
 
+.PHONY: install-dev
 install-dev:
-	pip install -r requirements-dev.txt
-	python setup.py develop
+	$(PIP) install -r requirements-dev.txt
+	$(PYTHON) setup.py develop
 
+.PHONY: check
+check: clean
+	$(PYTHON) setup.py test
+
+.PHONY: clean
 clean:
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -type d | xargs rm -fr
 
+.PHONY: distclean
 distclean: clean
-	rm -fr *.egg *.egg-info/
+	rm -fr *.egg *.egg-info/ .eggs/
 
+.PHONY:
+mostlyclean: clean distclean
+	rm -rf "$(VENV_DIR)"
+
+.PHONY: docs
 docs: install-dev
-	python scripts/gen-cli-docs.py
+	$(PYTHON) scripts/gen-cli-docs.py
 	mkdocs build


### PR DESCRIPTION
 - Non-build targets must be .PHONY – corrected.

 - PYTHON and PIP variables from an environment.

 - Additional 'check' and 'clean' targets added for a convinience.

 - New make targets '$(VENV_DIR)' and 'env' added. These targets are
   suitable for creation of the isolated developer's environment within
   application directory.