### PR TITLE
Add timespan selection helper options for the `report` and `log` commands

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -120,6 +120,11 @@ By default, the sessions from the last 7 days are printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
 must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
+You can also use special shortcut options for easier timespan control:
+`--day` sets the log timespan to the current day (beginning at 00:00h)
+and `--year`, `--month` and `--week` to the current year, month or week
+respectively.
+
 You can limit the log to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the log.
@@ -159,6 +164,10 @@ Flag | Help
 -----|-----
 `-f, --from DATE` | The date from when the log should start. Defaults to seven days ago.
 `-t, --to DATE` | The date at which the log should stop (inclusive). Defaults to tomorrow.
+`-y, --year` | Reports activity for the current year.
+`-m, --month` | Reports activity for the current month.
+`-w, --week` | Reports activity for the current week.
+`-d, --day` | Reports activity for the current day.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `--help` | Show this message and exit.
@@ -308,6 +317,11 @@ By default, the time spent the last 7 days is printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
 must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
+You can also use special shortcut options for easier timespan control:
+`--day` sets the report timespan to the current day (beginning at 00:00h)
+and `--year`, `--month` and `--week` to the current year, month or week
+respectively.
+
 You can limit the report to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the report.
@@ -360,6 +374,10 @@ Flag | Help
 -----|-----
 `-f, --from DATE` | The date from when the report should start. Defaults to seven days ago.
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
+`-y, --year` | Reports activity for the current year.
+`-m, --month` | Reports activity for the current month.
+`-w, --week` | Reports activity for the current week.
+`-d, --day` | Reports activity for the current day.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `--help` | Show this message and exit.

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -15,7 +15,27 @@ import click
 from . import watson
 from .frames import Frame
 from .utils import (format_timedelta, get_frame_from_argument, options,
-                    sorted_groupby, style)
+                    sorted_groupby, style, get_start_time_for_period)
+
+
+class MutuallyExclusiveOption(click.Option):
+    def __init__(self, *args, **kwargs):
+        self.mutually_exclusive = set(kwargs.pop('mutually_exclusive', []))
+        super(MutuallyExclusiveOption, self).__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        if self.mutually_exclusive.intersection(opts) and self.name in opts:
+            raise click.UsageError(
+                '`--{name}` is mutually exclusive with the following options: '
+                '{options}'.format(name=self.name.replace('_', ''),
+                                   options=', '
+                                   .join(['`--{}`'.format(_) for _ in
+                                         self.mutually_exclusive]))
+            )
+
+        return super(MutuallyExclusiveOption, self).handle_parse_result(
+            ctx, opts, args
+        )
 
 
 class WatsonCliError(click.ClickException):
@@ -265,14 +285,36 @@ def status(watson):
     ))
 
 
+_SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
+
+
 @cli.command()
-@click.option('-f', '--from', 'from_', type=Date,
+@click.option('-f', '--from', 'from_', cls=MutuallyExclusiveOption, type=Date,
               default=arrow.now().replace(days=-7),
+              mutually_exclusive=_SHORTCUT_OPTIONS,
               help="The date from when the report should start. Defaults "
               "to seven days ago.")
-@click.option('-t', '--to', type=Date, default=arrow.now(),
+@click.option('-t', '--to', cls=MutuallyExclusiveOption, type=Date,
+              default=arrow.now(),
+              mutually_exclusive=_SHORTCUT_OPTIONS,
               help="The date at which the report should stop (inclusive). "
               "Defaults to tomorrow.")
+@click.option('-y', '--year', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('year'),
+              mutually_exclusive=['day', 'week', 'month'],
+              help='Reports activity for the current year.')
+@click.option('-m', '--month', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('month'),
+              mutually_exclusive=['day', 'week', 'year'],
+              help='Reports activity for the current month.')
+@click.option('-w', '--week', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('week'),
+              mutually_exclusive=['day', 'month', 'year'],
+              help='Reports activity for the current week.')
+@click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('day'),
+              mutually_exclusive=['week', 'month', 'year'],
+              help='Reports activity for the current day.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Reports activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -281,7 +323,7 @@ def status(watson):
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.pass_obj
-def report(watson, from_, to, projects, tags):
+def report(watson, from_, to, projects, tags, year, month, week, day):
     """
     Display a report of the time spent on each project.
 
@@ -292,6 +334,11 @@ def report(watson, from_, to, projects, tags):
     By default, the time spent the last 7 days is printed. This timespan
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+
+    You can also use special shortcut options for easier timespan control:
+    `--day` sets the report timespan to the current day (beginning at 00:00h)
+    and `--year`, `--month` and `--week` to the current year, month or week
+    respectively.
 
     You can limit the report to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
@@ -339,6 +386,10 @@ def report(watson, from_, to, projects, tags):
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
     """
+    for start_time in (_ for _ in [day, week, month, year]
+                       if _ is not None):
+        from_ = start_time
+
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
 
@@ -407,6 +458,22 @@ def report(watson, from_, to, projects, tags):
 @click.option('-t', '--to', type=Date, default=arrow.now(),
               help="The date at which the log should stop (inclusive). "
               "Defaults to tomorrow.")
+@click.option('-y', '--year', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('year'),
+              mutually_exclusive=['day', 'week', 'month'],
+              help='Reports activity for the current year.')
+@click.option('-m', '--month', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('month'),
+              mutually_exclusive=['day', 'week', 'year'],
+              help='Reports activity for the current month.')
+@click.option('-w', '--week', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('week'),
+              mutually_exclusive=['day', 'month', 'year'],
+              help='Reports activity for the current week.')
+@click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('day'),
+              mutually_exclusive=['week', 'month', 'year'],
+              help='Reports activity for the current day.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Logs activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -415,13 +482,18 @@ def report(watson, from_, to, projects, tags):
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.pass_obj
-def log(watson, from_, to, projects, tags):
+def log(watson, from_, to, projects, tags, year, month, week, day):
     """
     Display each recorded session during the given timespan.
 
     By default, the sessions from the last 7 days are printed. This timespan
     can be controlled with the `--from` and `--to` arguments. The dates
     must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+
+    You can also use special shortcut options for easier timespan control:
+    `--day` sets the log timespan to the current day (beginning at 00:00h)
+    and `--year`, `--month` and `--week` to the current year, month or week
+    respectively.
 
     You can limit the log to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
@@ -456,6 +528,10 @@ def log(watson, from_, to, projects, tags):
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
     """  # noqa
+    for start_time in (_ for _ in [day, week, month, year]
+                       if _ is not None):
+        from_ = start_time
+
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -1,6 +1,8 @@
 import itertools
+import datetime
 
 import click
+import arrow
 
 from click.exceptions import UsageError
 
@@ -111,3 +113,28 @@ def get_frame_from_argument(watson, arg):
             style('error', "No frame found with id"),
             style('short_id', arg))
         )
+
+
+def get_start_time_for_period(period):
+    # Using now() from datetime instead of arrow for mocking compatibility.
+    now = arrow.Arrow.fromdatetime(datetime.datetime.now())
+    date = now.date()
+
+    day = date.day
+    month = date.month
+    year = date.year
+
+    weekday = now.weekday()
+
+    if period == 'day':
+        start_time = arrow.Arrow(year, month, day)
+    elif period == 'week':
+        start_time = arrow.Arrow.fromdate(now.replace(days=-weekday).date())
+    elif period == 'month':
+        start_time = arrow.Arrow(year, month, 1)
+    elif period == 'year':
+        start_time = arrow.Arrow(year, 1, 1)
+    else:
+        raise ValueError('Unsupported period value: {}'.format(period))
+
+    return start_time


### PR DESCRIPTION
- Shortcut options (`--year`, `--month`, `--week`, `--day`) were added
  to the 'report' and 'log' command. They are intended for an easier
  timespan selection for common use cases (e.g., how much time did
  I spent on my project during the current year, month, week or day?)
  without needing to use the appropriate `--from` and `--to` options.

- Shortcut options are mutually exclusive with each other and with the
  `--from` and `--to` options.

- A new `watson.utils.get_start_time_for_period()` function helps to
  determine the datetime (Arrow object) for the start of the current
  year, month, week or day.