### PR TITLE
Fix import of tzutc from dateutil to also work with versions < 2.5

### DIFF
--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -18,7 +18,7 @@ import pytest
 import requests
 import arrow
 
-from dateutil.tz.tz import tzutc
+from dateutil.tz import tzutc
 
 from click import get_app_dir
 from watson import Watson, WatsonError


### PR DESCRIPTION
Signed-off-by: Christopher Arndt <chris@chrisarndt.de>