### PR TITLE
Suggest to use tox by default, describe how to run tests

### DIFF
--- a/docs/contributing/hack.md
+++ b/docs/contributing/hack.md
@@ -22,9 +22,10 @@ Ready to contribute? Here's how to set up *Watson* for local development.
 
     Now you can make your changes locally.
 
-5.  When you're done making changes, check that your changes pass the tests:
+5.  When you're done making changes, check that your changes pass the tests
+    (see [Run the tests](#run-the-tests)):
 
-        $ py.test
+        $ tox
 
 6. If you have added a new command or updated/fixed docstrings, please update the documentation:
 
@@ -34,6 +35,23 @@ Ready to contribute? Here's how to set up *Watson* for local development.
 
         $ git add .
         $ git commit -m "Your detailed description of your changes."
-        $ git push origin name-of-your-bugfix-or-feature
+        $ git push -u origin name-of-your-bugfix-or-feature
 
 8.  After [reading this](./pr-guidelines.md), submit a pull request through the GitHub website.
+
+
+<a href="#run-the-tests"></a>
+## Run the tests
+
+The tests use [pytest](http://pytest.org/). To run them with the default Python
+interpreter:
+
+    $ py.test -v tests/
+
+To run the tests via [tox](http://tox.testrun.org/) with all Python versions
+which are available on your system and are defined in the `tox.ini` file,
+simply run:
+
+    $ tox
+
+This will also check the source code with [flake8](http://flake8.pycqa.org).

--- a/docs/contributing/pr-guidelines.md
+++ b/docs/contributing/pr-guidelines.md
@@ -3,7 +3,9 @@
 > *nota bene*
 >
 > Open a pull-request even if your contribution is not ready yet! It can
-> be discussed and improved collaboratively!
+> be discussed and improved collaboratively! You may prefix the title of
+> your pull-request with "WIP: " to make it clear that it is not yet ready
+> for merging.
 
 Before we merge a pull request, we check that it meets these guidelines:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist = flake8,py27,py33,py34,py35
+skip_missing_interpreters = True
 
 [testenv]
-deps=pytest
-     mock
-     pytest-datafiles
-commands=py.test -vs tests/
-usedevelop=True
+deps = pytest
+    mock
+    pytest-datafiles
+commands = py.test -vs tests/
+usedevelop = True
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Also sets the tox config option [skip_missing_interpreters](https://testrun.org/tox/latest/config.html#confval-skip_missing_interpreters=BOOL) to `True`, so tox can be run even you don't have all the Python versions defined in `tox.ini` installed.

Lastly, adds a note in the PR guidelines about marking WIP PRs with "WIP:".

Replaces #104.