### PR TITLE
Refactor tests for different modules, fixtures and test utils into separate modules

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,9 @@ mkdocs
 flake8
 # mock>1.0.1 requires setuptools>17
 mock<=1.0.1
+py
 pytest
 pytest-datafiles
+pytest-mock
 pytest-runner
 tox

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,44 @@
+"""Utility functions for the unit tests."""
+
+import datetime
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+
+def mock_datetime(dt, dt_module):
+
+    class DateTimeMeta(type):
+
+        @classmethod
+        def __instancecheck__(mcs, obj):
+            return isinstance(obj, datetime.datetime)
+
+    class BaseMockedDateTime(datetime.datetime):
+
+        @classmethod
+        def now(cls, tz=None):
+            return dt.replace(tzinfo=tz)
+
+        @classmethod
+        def utcnow(cls):
+            return dt
+
+        @classmethod
+        def today(cls):
+            return dt
+
+    MockedDateTime = DateTimeMeta('datetime', (BaseMockedDateTime,), {})
+
+    return mock.patch.object(dt_module, 'datetime', MockedDateTime)
+
+
+def mock_read(content):
+    return lambda self, name: self._read(StringIO(content), name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Provide fixtures for pytest-based unit tests."""
+
+import pytest
+
+from watson import Watson
+
+
+@pytest.fixture
+def config_dir(tmpdir):
+    return str(tmpdir.mkdir('config'))
+
+
+@pytest.fixture
+def watson(config_dir):
+    return Watson(config_dir=config_dir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,5 @@
 """Unit tests for the 'config' module."""
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 import pytest
 
 from watson.config import ConfigParser
@@ -12,23 +7,23 @@ from watson.config import ConfigParser
 from . import mock_read
 
 
-def test_config_get(watson):
+def test_config_get(mock, watson):
     content = u"""
 [backend]
 url = foo
 token =
     """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.get('backend', 'url') == 'foo'
-        assert config.get('backend', 'token') == ''
-        assert config.get('backend', 'foo') is None
-        assert config.get('backend', 'foo', 'bar') == 'bar'
-        assert config.get('option', 'spamm') is None
-        assert config.get('option', 'spamm', 'eggs') == 'eggs'
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    config = watson.config
+    assert config.get('backend', 'url') == 'foo'
+    assert config.get('backend', 'token') == ''
+    assert config.get('backend', 'foo') is None
+    assert config.get('backend', 'foo', 'bar') == 'bar'
+    assert config.get('option', 'spamm') is None
+    assert config.get('option', 'spamm', 'eggs') == 'eggs'
 
 
-def test_config_getboolean(watson):
+def test_config_getboolean(mock, watson):
     content = u"""
 [options]
 flag1 = 1
@@ -38,45 +33,45 @@ flag4 = yes
 flag5 = false
 flag6 =
     """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.getboolean('options', 'flag1') is True
-        assert config.getboolean('options', 'flag1', False) is True
-        assert config.getboolean('options', 'flag2') is True
-        assert config.getboolean('options', 'flag3') is True
-        assert config.getboolean('options', 'flag4') is True
-        assert config.getboolean('options', 'flag5') is False
-        assert config.getboolean('options', 'flag6') is False
-        assert config.getboolean('options', 'flag6', True) is True
-        assert config.getboolean('options', 'missing') is False
-        assert config.getboolean('options', 'missing', True) is True
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    config = watson.config
+    assert config.getboolean('options', 'flag1') is True
+    assert config.getboolean('options', 'flag1', False) is True
+    assert config.getboolean('options', 'flag2') is True
+    assert config.getboolean('options', 'flag3') is True
+    assert config.getboolean('options', 'flag4') is True
+    assert config.getboolean('options', 'flag5') is False
+    assert config.getboolean('options', 'flag6') is False
+    assert config.getboolean('options', 'flag6', True) is True
+    assert config.getboolean('options', 'missing') is False
+    assert config.getboolean('options', 'missing', True) is True
 
 
-def test_config_getint(watson):
+def test_config_getint(mock, watson):
     content = u"""
 [options]
 value1 = 42
 value2 = spamm
 value3 =
     """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.getint('options', 'value1') == 42
-        assert config.getint('options', 'value1', 666) == 42
-        assert config.getint('options', 'missing') is None
-        assert config.getint('options', 'missing', 23) == 23
-        # default is not converted!
-        assert config.getint('options', 'missing', '42') == '42'
-        assert config.getint('options', 'missing', 6.66) == 6.66
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    config = watson.config
+    assert config.getint('options', 'value1') == 42
+    assert config.getint('options', 'value1', 666) == 42
+    assert config.getint('options', 'missing') is None
+    assert config.getint('options', 'missing', 23) == 23
+    # default is not converted!
+    assert config.getint('options', 'missing', '42') == '42'
+    assert config.getint('options', 'missing', 6.66) == 6.66
 
-        with pytest.raises(ValueError):
-            config.getint('options', 'value2')
+    with pytest.raises(ValueError):
+        config.getint('options', 'value2')
 
-        with pytest.raises(ValueError):
-            config.getint('options', 'value3')
+    with pytest.raises(ValueError):
+        config.getint('options', 'value3')
 
 
-def test_config_getfloat(watson):
+def test_config_getfloat(mock, watson):
     content = u"""
 [options]
 value1 = 3.14
@@ -85,25 +80,25 @@ value3 = spamm
 value4 =
     """
 
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.getfloat('options', 'value1') == 3.14
-        assert config.getfloat('options', 'value1', 6.66) == 3.14
-        assert config.getfloat('options', 'value2') == 42.0
-        assert isinstance(config.getfloat('options', 'value2'), float)
-        assert config.getfloat('options', 'missing') is None
-        assert config.getfloat('options', 'missing', 3.14) == 3.14
-        # default is not converted!
-        assert config.getfloat('options', 'missing', '3.14') == '3.14'
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    config = watson.config
+    assert config.getfloat('options', 'value1') == 3.14
+    assert config.getfloat('options', 'value1', 6.66) == 3.14
+    assert config.getfloat('options', 'value2') == 42.0
+    assert isinstance(config.getfloat('options', 'value2'), float)
+    assert config.getfloat('options', 'missing') is None
+    assert config.getfloat('options', 'missing', 3.14) == 3.14
+    # default is not converted!
+    assert config.getfloat('options', 'missing', '3.14') == '3.14'
 
-        with pytest.raises(ValueError):
-            config.getfloat('options', 'value3')
+    with pytest.raises(ValueError):
+        config.getfloat('options', 'value3')
 
-        with pytest.raises(ValueError):
-            config.getfloat('options', 'value4')
+    with pytest.raises(ValueError):
+        config.getfloat('options', 'value4')
 
 
-def test_config_getlist(watson):
+def test_config_getlist(mock, watson):
     content = u"""
 # empty lines in option values (including the first one) are discarded
 [options]
@@ -126,28 +121,28 @@ value5 = one
    two #three
    four # five
 """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        gl = watson.config.getlist
-        assert gl('options', 'value1') == ['one', 'two three', 'four',
-                                           'five six']
-        assert gl('options', 'value2') == ['one', 'two three', 'four',
-                                           'five  six']
-        assert gl('options', 'value3') == ['one', 'two  three']
-        assert gl('options', 'value4') == ['one', 'two three', 'four']
-        assert gl('options', 'value5') == ['one', 'two #three', 'four # five']
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    gl = watson.config.getlist
+    assert gl('options', 'value1') == ['one', 'two three', 'four',
+                                       'five six']
+    assert gl('options', 'value2') == ['one', 'two three', 'four',
+                                       'five  six']
+    assert gl('options', 'value3') == ['one', 'two  three']
+    assert gl('options', 'value4') == ['one', 'two three', 'four']
+    assert gl('options', 'value5') == ['one', 'two #three', 'four # five']
 
-        # default values
-        assert gl('options', 'novalue') == []
-        assert gl('options', 'novalue', None) == []
-        assert gl('options', 'novalue', 42) == 42
-        assert gl('nosection', 'dummy') == []
-        assert gl('nosection', 'dummy', None) == []
-        assert gl('nosection', 'dummy', 42) == 42
+    # default values
+    assert gl('options', 'novalue') == []
+    assert gl('options', 'novalue', None) == []
+    assert gl('options', 'novalue', 42) == 42
+    assert gl('nosection', 'dummy') == []
+    assert gl('nosection', 'dummy', None) == []
+    assert gl('nosection', 'dummy', 42) == 42
 
-        default = gl('nosection', 'dummy')
-        default.append(42)
-        assert gl('nosection', 'dummy') != [42], (
-            "Modifying default return value should not have side effect.")
+    default = gl('nosection', 'dummy')
+    default.append(42)
+    assert gl('nosection', 'dummy') != [42], (
+        "Modifying default return value should not have side effect.")
 
 
 def test_set_config(watson):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,158 @@
+"""Unit tests for the 'config' module."""
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import pytest
+
+from watson.config import ConfigParser
+
+from . import mock_read
+
+
+def test_config_get(watson):
+    content = u"""
+[backend]
+url = foo
+token =
+    """
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        config = watson.config
+        assert config.get('backend', 'url') == 'foo'
+        assert config.get('backend', 'token') == ''
+        assert config.get('backend', 'foo') is None
+        assert config.get('backend', 'foo', 'bar') == 'bar'
+        assert config.get('option', 'spamm') is None
+        assert config.get('option', 'spamm', 'eggs') == 'eggs'
+
+
+def test_config_getboolean(watson):
+    content = u"""
+[options]
+flag1 = 1
+flag2 = ON
+flag3 = True
+flag4 = yes
+flag5 = false
+flag6 =
+    """
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        config = watson.config
+        assert config.getboolean('options', 'flag1') is True
+        assert config.getboolean('options', 'flag1', False) is True
+        assert config.getboolean('options', 'flag2') is True
+        assert config.getboolean('options', 'flag3') is True
+        assert config.getboolean('options', 'flag4') is True
+        assert config.getboolean('options', 'flag5') is False
+        assert config.getboolean('options', 'flag6') is False
+        assert config.getboolean('options', 'flag6', True) is True
+        assert config.getboolean('options', 'missing') is False
+        assert config.getboolean('options', 'missing', True) is True
+
+
+def test_config_getint(watson):
+    content = u"""
+[options]
+value1 = 42
+value2 = spamm
+value3 =
+    """
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        config = watson.config
+        assert config.getint('options', 'value1') == 42
+        assert config.getint('options', 'value1', 666) == 42
+        assert config.getint('options', 'missing') is None
+        assert config.getint('options', 'missing', 23) == 23
+        # default is not converted!
+        assert config.getint('options', 'missing', '42') == '42'
+        assert config.getint('options', 'missing', 6.66) == 6.66
+
+        with pytest.raises(ValueError):
+            config.getint('options', 'value2')
+
+        with pytest.raises(ValueError):
+            config.getint('options', 'value3')
+
+
+def test_config_getfloat(watson):
+    content = u"""
+[options]
+value1 = 3.14
+value2 = 42
+value3 = spamm
+value4 =
+    """
+
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        config = watson.config
+        assert config.getfloat('options', 'value1') == 3.14
+        assert config.getfloat('options', 'value1', 6.66) == 3.14
+        assert config.getfloat('options', 'value2') == 42.0
+        assert isinstance(config.getfloat('options', 'value2'), float)
+        assert config.getfloat('options', 'missing') is None
+        assert config.getfloat('options', 'missing', 3.14) == 3.14
+        # default is not converted!
+        assert config.getfloat('options', 'missing', '3.14') == '3.14'
+
+        with pytest.raises(ValueError):
+            config.getfloat('options', 'value3')
+
+        with pytest.raises(ValueError):
+            config.getfloat('options', 'value4')
+
+
+def test_config_getlist(watson):
+    content = u"""
+# empty lines in option values (including the first one) are discarded
+[options]
+value1 =
+    one
+
+    two three
+    four
+    five six
+# multiple inner space preserved
+value2 = one  "two three" four 'five  six'
+value3 = one
+    two  three
+# outer space stripped
+value4 = one
+     two three
+    four
+# hash char not at start of line does not start comment
+value5 = one
+   two #three
+   four # five
+"""
+    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
+        gl = watson.config.getlist
+        assert gl('options', 'value1') == ['one', 'two three', 'four',
+                                           'five six']
+        assert gl('options', 'value2') == ['one', 'two three', 'four',
+                                           'five  six']
+        assert gl('options', 'value3') == ['one', 'two  three']
+        assert gl('options', 'value4') == ['one', 'two three', 'four']
+        assert gl('options', 'value5') == ['one', 'two #three', 'four # five']
+
+        # default values
+        assert gl('options', 'novalue') == []
+        assert gl('options', 'novalue', None) == []
+        assert gl('options', 'novalue', 42) == 42
+        assert gl('nosection', 'dummy') == []
+        assert gl('nosection', 'dummy', None) == []
+        assert gl('nosection', 'dummy', 42) == 42
+
+        default = gl('nosection', 'dummy')
+        default.append(42)
+        assert gl('nosection', 'dummy') != [42], (
+            "Modifying default return value should not have side effect.")
+
+
+def test_set_config(watson):
+    config = ConfigParser()
+    config.set('foo', 'bar', 'lol')
+    watson.config = config
+
+    assert watson.config.get('foo', 'bar') == 'lol'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,108 @@
+"""Unit tests for the 'utils' module."""
+
+import functools
+import os
+import datetime
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import pytest
+from dateutil.tz import tzutc
+
+from watson.utils import get_start_time_for_period, make_json_writer, safe_save
+from . import mock_datetime
+
+
+_dt = functools.partial(datetime.datetime, tzinfo=tzutc())
+
+
+@pytest.mark.parametrize('now, mode, start_time', [
+    (_dt(2016, 6, 2), 'year', _dt(2016, 1, 1)),
+    (_dt(2016, 6, 2), 'month', _dt(2016, 6, 1)),
+    (_dt(2016, 6, 2), 'week', _dt(2016, 5, 30)),
+    (_dt(2016, 6, 2), 'day', _dt(2016, 6, 2)),
+
+    (_dt(2012, 2, 24), 'year', _dt(2012, 1, 1)),
+    (_dt(2012, 2, 24), 'month', _dt(2012, 2, 1)),
+    (_dt(2012, 2, 24), 'week', _dt(2012, 2, 20)),
+    (_dt(2012, 2, 24), 'day', _dt(2012, 2, 24)),
+])
+def test_get_start_time_for_period(now, mode, start_time):
+    with mock_datetime(now, datetime):
+        assert get_start_time_for_period(mode).datetime == start_time
+
+
+def test_make_json_writer():
+    fp = StringIO()
+    writer = make_json_writer(lambda: {'foo': 42})
+    writer(fp)
+    assert fp.getvalue() == '{\n "foo": 42\n}'
+
+
+def test_make_json_writer_with_args():
+    fp = StringIO()
+    writer = make_json_writer(lambda x: {'foo': x}, 23)
+    writer(fp)
+    assert fp.getvalue() == '{\n "foo": 23\n}'
+
+
+def test_make_json_writer_with_kwargs():
+    fp = StringIO()
+    writer = make_json_writer(lambda foo=None: {'foo': foo}, foo='bar')
+    writer(fp)
+    assert fp.getvalue() == '{\n "foo": "bar"\n}'
+
+
+def test_safe_save(config_dir):
+    save_file = os.path.join(config_dir, 'test')
+    backup_file = os.path.join(config_dir, 'test' + '.bak')
+
+    assert not os.path.exists(save_file)
+    safe_save(save_file, lambda f: f.write("Success"))
+    assert os.path.exists(save_file)
+    assert not os.path.exists(backup_file)
+
+    with open(save_file) as fp:
+        assert fp.read() == "Success"
+
+    safe_save(save_file, "Again")
+    assert os.path.exists(backup_file)
+
+    with open(save_file) as fp:
+        assert fp.read() == "Again"
+
+    with open(backup_file) as fp:
+        assert fp.read() == "Success"
+
+    assert os.path.getmtime(save_file) >= os.path.getmtime(backup_file)
+
+
+def test_safe_save_with_exception(config_dir):
+    save_file = os.path.join(config_dir, 'test')
+    backup_file = os.path.join(config_dir, 'test' + '.bak')
+
+    def failing_writer(f):
+        raise RuntimeError("Save failed.")
+
+    assert not os.path.exists(save_file)
+
+    with pytest.raises(RuntimeError):
+        safe_save(save_file, failing_writer)
+
+    assert not os.path.exists(save_file)
+    assert not os.path.exists(backup_file)
+
+    safe_save(save_file, lambda f: f.write("Success"))
+    assert os.path.exists(save_file)
+    assert not os.path.exists(backup_file)
+
+    with pytest.raises(RuntimeError):
+        safe_save(save_file, failing_writer)
+
+    with open(save_file) as fp:
+        assert fp.read() == "Success"
+
+    assert not os.path.exists(backup_file)

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -1,84 +1,37 @@
-import sys
+"""Unit tests for the main 'watson' module."""
+
 import json
 import os
-import datetime
+import sys
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 import py
 import pytest
 import requests
 import arrow
 
-from dateutil.tz import tzutc
-
 from click import get_app_dir
 from watson import Watson, WatsonError
 from watson.watson import ConfigurationError, ConfigParser
-from watson.utils import get_start_time_for_period, make_json_writer, safe_save
+
+from . import mock_read
 
 
+PY2 = sys.version_info[0] == 2
 TEST_FIXTURE_DIR = py.path.local(
     os.path.dirname(
         os.path.realpath(__file__)
         )
     ) / 'resources'
 
-PY2 = sys.version_info[0] == 2
-
 if not PY2:
     builtins = 'builtins'
 else:
     builtins = '__builtin__'
-
-
-def mock_datetime(dt, dt_module):
-
-    class DateTimeMeta(type):
-
-        @classmethod
-        def __instancecheck__(mcs, obj):
-            return isinstance(obj, datetime.datetime)
-
-    class BaseMockedDateTime(datetime.datetime):
-
-        @classmethod
-        def now(cls, tz=None):
-            return dt.replace(tzinfo=tz)
-
-        @classmethod
-        def utcnow(cls):
-            return dt
-
-        @classmethod
-        def today(cls):
-            return dt
-
-    MockedDateTime = DateTimeMeta('datetime', (BaseMockedDateTime,), {})
-
-    return mock.patch.object(dt_module, 'datetime', MockedDateTime)
-
-
-@pytest.fixture
-def config_dir(tmpdir):
-    return str(tmpdir.mkdir('config'))
-
-
-def mock_read(content):
-    return lambda self, name: self._read(StringIO(content), name)
-
-
-@pytest.fixture
-def watson(config_dir):
-    return Watson(config_dir=config_dir)
 
 
 # current
@@ -259,152 +212,6 @@ toto
 def test_empty_config(watson):
     with mock.patch.object(ConfigParser, 'read', mock_read(u'')):
         assert len(watson.config.sections()) == 0
-
-
-def test_config_get(watson):
-    content = u"""
-[backend]
-url = foo
-token =
-    """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.get('backend', 'url') == 'foo'
-        assert config.get('backend', 'token') == ''
-        assert config.get('backend', 'foo') is None
-        assert config.get('backend', 'foo', 'bar') == 'bar'
-        assert config.get('option', 'spamm') is None
-        assert config.get('option', 'spamm', 'eggs') == 'eggs'
-
-
-def test_config_getboolean(watson):
-    content = u"""
-[options]
-flag1 = 1
-flag2 = ON
-flag3 = True
-flag4 = yes
-flag5 = false
-flag6 =
-    """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.getboolean('options', 'flag1') is True
-        assert config.getboolean('options', 'flag1', False) is True
-        assert config.getboolean('options', 'flag2') is True
-        assert config.getboolean('options', 'flag3') is True
-        assert config.getboolean('options', 'flag4') is True
-        assert config.getboolean('options', 'flag5') is False
-        assert config.getboolean('options', 'flag6') is False
-        assert config.getboolean('options', 'flag6', True) is True
-        assert config.getboolean('options', 'missing') is False
-        assert config.getboolean('options', 'missing', True) is True
-
-
-def test_config_getint(watson):
-    content = u"""
-[options]
-value1 = 42
-value2 = spamm
-value3 =
-    """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.getint('options', 'value1') == 42
-        assert config.getint('options', 'value1', 666) == 42
-        assert config.getint('options', 'missing') is None
-        assert config.getint('options', 'missing', 23) == 23
-        # default is not converted!
-        assert config.getint('options', 'missing', '42') == '42'
-        assert config.getint('options', 'missing', 6.66) == 6.66
-
-        with pytest.raises(ValueError):
-            config.getint('options', 'value2')
-
-        with pytest.raises(ValueError):
-            config.getint('options', 'value3')
-
-
-def test_config_getfloat(watson):
-    content = u"""
-[options]
-value1 = 3.14
-value2 = 42
-value3 = spamm
-value4 =
-    """
-
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        config = watson.config
-        assert config.getfloat('options', 'value1') == 3.14
-        assert config.getfloat('options', 'value1', 6.66) == 3.14
-        assert config.getfloat('options', 'value2') == 42.0
-        assert isinstance(config.getfloat('options', 'value2'), float)
-        assert config.getfloat('options', 'missing') is None
-        assert config.getfloat('options', 'missing', 3.14) == 3.14
-        # default is not converted!
-        assert config.getfloat('options', 'missing', '3.14') == '3.14'
-
-        with pytest.raises(ValueError):
-            config.getfloat('options', 'value3')
-
-        with pytest.raises(ValueError):
-            config.getfloat('options', 'value4')
-
-
-def test_config_getlist(watson):
-    content = u"""
-# empty lines in option values (including the first one) are discarded
-[options]
-value1 =
-    one
-
-    two three
-    four
-    five six
-# multiple inner space preserved
-value2 = one  "two three" four 'five  six'
-value3 = one
-    two  three
-# outer space stripped
-value4 = one
-     two three
-    four
-# hash char not at start of line does not start comment
-value5 = one
-   two #three
-   four # five
-"""
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        gl = watson.config.getlist
-        assert gl('options', 'value1') == ['one', 'two three', 'four',
-                                           'five six']
-        assert gl('options', 'value2') == ['one', 'two three', 'four',
-                                           'five  six']
-        assert gl('options', 'value3') == ['one', 'two  three']
-        assert gl('options', 'value4') == ['one', 'two three', 'four']
-        assert gl('options', 'value5') == ['one', 'two #three', 'four # five']
-
-        # default values
-        assert gl('options', 'novalue') == []
-        assert gl('options', 'novalue', None) == []
-        assert gl('options', 'novalue', 42) == 42
-        assert gl('nosection', 'dummy') == []
-        assert gl('nosection', 'dummy', None) == []
-        assert gl('nosection', 'dummy', 42) == 42
-
-        default = gl('nosection', 'dummy')
-        default.append(42)
-        assert gl('nosection', 'dummy') != [42], (
-            "Modifying default return value should not have side effect.")
-
-
-def test_set_config(watson):
-    config = ConfigParser()
-    config.set('foo', 'bar', 'lol')
-    watson.config = config
-
-    watson.config.get('foo', 'bar') == 'lol'
 
 
 # start
@@ -896,100 +703,3 @@ def test_merge_report(watson, datafiles):
 
     assert conflicting[0].id == '2'
     assert merging[0].id == '3'
-
-
-# report/log
-
-_dt = datetime.datetime
-_tz = {'tzinfo': tzutc()}
-
-
-@pytest.mark.parametrize('now, mode, start_time', [
-    (_dt(2016, 6, 2, **_tz), 'year', _dt(2016, 1, 1, **_tz)),
-    (_dt(2016, 6, 2, **_tz), 'month', _dt(2016, 6, 1, **_tz)),
-    (_dt(2016, 6, 2, **_tz), 'week', _dt(2016, 5, 30, **_tz)),
-    (_dt(2016, 6, 2, **_tz), 'day', _dt(2016, 6, 2, **_tz)),
-
-    (_dt(2012, 2, 24, **_tz), 'year', _dt(2012, 1, 1, **_tz)),
-    (_dt(2012, 2, 24, **_tz), 'month', _dt(2012, 2, 1, **_tz)),
-    (_dt(2012, 2, 24, **_tz), 'week', _dt(2012, 2, 20, **_tz)),
-    (_dt(2012, 2, 24, **_tz), 'day', _dt(2012, 2, 24, **_tz)),
-])
-def test_get_start_time_for_period(now, mode, start_time):
-    with mock_datetime(now, datetime):
-        assert get_start_time_for_period(mode).datetime == start_time
-
-
-# utils
-
-def test_make_json_writer():
-    fp = StringIO()
-    writer = make_json_writer(lambda: {'foo': 42})
-    writer(fp)
-    assert fp.getvalue() == '{\n "foo": 42\n}'
-
-
-def test_make_json_writer_with_args():
-    fp = StringIO()
-    writer = make_json_writer(lambda x: {'foo': x}, 23)
-    writer(fp)
-    assert fp.getvalue() == '{\n "foo": 23\n}'
-
-
-def test_make_json_writer_with_kwargs():
-    fp = StringIO()
-    writer = make_json_writer(lambda foo=None: {'foo': foo}, foo='bar')
-    writer(fp)
-    assert fp.getvalue() == '{\n "foo": "bar"\n}'
-
-
-def test_safe_save(config_dir):
-    save_file = os.path.join(config_dir, 'test')
-    backup_file = os.path.join(config_dir, 'test' + '.bak')
-
-    assert not os.path.exists(save_file)
-    safe_save(save_file, lambda f: f.write("Success"))
-    assert os.path.exists(save_file)
-    assert not os.path.exists(backup_file)
-
-    with open(save_file) as fp:
-        assert fp.read() == "Success"
-
-    safe_save(save_file, "Again")
-    assert os.path.exists(backup_file)
-
-    with open(save_file) as fp:
-        assert fp.read() == "Again"
-
-    with open(backup_file) as fp:
-        assert fp.read() == "Success"
-
-    assert os.path.getmtime(save_file) >= os.path.getmtime(backup_file)
-
-
-def test_safe_save_with_exception(config_dir):
-    save_file = os.path.join(config_dir, 'test')
-    backup_file = os.path.join(config_dir, 'test' + '.bak')
-
-    def failing_writer(f):
-        raise RuntimeError("Save failed.")
-
-    assert not os.path.exists(save_file)
-
-    with pytest.raises(RuntimeError):
-        safe_save(save_file, failing_writer)
-
-    assert not os.path.exists(save_file)
-    assert not os.path.exists(backup_file)
-
-    safe_save(save_file, lambda f: f.write("Success"))
-    assert os.path.exists(save_file)
-    assert not os.path.exists(backup_file)
-
-    with pytest.raises(RuntimeError):
-        safe_save(save_file, failing_writer)
-
-    with open(save_file) as fp:
-        assert fp.read() == "Success"
-
-    assert not os.path.exists(backup_file)

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -4,11 +4,6 @@ import json
 import os
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 import py
 import pytest
 import requests
@@ -36,161 +31,160 @@ else:
 
 # current
 
-def test_current(watson):
+def test_current(mock, watson):
     content = json.dumps({'project': 'foo', 'start': 0, 'tags': ['A', 'B']})
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert watson.current['project'] == 'foo'
-        assert watson.current['start'] == arrow.get(0)
-        assert watson.current['tags'] == ['A', 'B']
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert watson.current['project'] == 'foo'
+    assert watson.current['start'] == arrow.get(0)
+    assert watson.current['tags'] == ['A', 'B']
 
 
-def test_current_with_empty_file(watson):
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data="")):
-        with mock.patch('os.path.getsize', return_value=0):
-            assert watson.current == {}
+def test_current_with_empty_file(mock, watson):
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=""))
+    mock.patch('os.path.getsize', return_value=0)
+    assert watson.current == {}
 
 
-def test_current_with_nonexistent_file(watson):
-    with mock.patch('%s.open' % builtins, side_effect=IOError):
-        assert watson.current == {}
+def test_current_with_nonexistent_file(mock, watson):
+    mock.patch('%s.open' % builtins, side_effect=IOError)
+    assert watson.current == {}
 
 
-def test_current_watson_non_valid_json(watson):
+def test_current_watson_non_valid_json(mock, watson):
     content = "{'foo': bar}"
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        with mock.patch('os.path.getsize', return_value=len(content)):
-            with pytest.raises(WatsonError):
-                watson.current
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    mock.patch('os.path.getsize', return_value=len(content))
+    with pytest.raises(WatsonError):
+        watson.current
 
 
-def test_current_with_given_state(config_dir):
+def test_current_with_given_state(config_dir, mock):
     content = json.dumps({'project': 'foo', 'start': 0})
     watson = Watson(current={'project': 'bar', 'start': 0},
                     config_dir=config_dir)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert watson.current['project'] == 'bar'
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert watson.current['project'] == 'bar'
 
 
-def test_current_with_empty_given_state(config_dir):
+def test_current_with_empty_given_state(config_dir, mock):
     content = json.dumps({'project': 'foo', 'start': 0})
     watson = Watson(current=[], config_dir=config_dir)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert watson.current == {}
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert watson.current == {}
 
 
 # last_sync
 
-def test_last_sync(watson):
+def test_last_sync(mock, watson):
     now = arrow.get(123)
     content = json.dumps(now.timestamp)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert watson.last_sync == now
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert watson.last_sync == now
 
 
-def test_last_sync_with_empty_file(watson):
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data="")):
-        with mock.patch('os.path.getsize', return_value=0):
-            assert watson.last_sync == arrow.get(0)
+def test_last_sync_with_empty_file(mock, watson):
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=""))
+    mock.patch('os.path.getsize', return_value=0)
+    assert watson.last_sync == arrow.get(0)
 
 
-def test_last_sync_with_nonexistent_file(watson):
-    with mock.patch('%s.open' % builtins, side_effect=IOError):
-        assert watson.last_sync == arrow.get(0)
+def test_last_sync_with_nonexistent_file(mock, watson):
+    mock.patch('%s.open' % builtins, side_effect=IOError)
+    assert watson.last_sync == arrow.get(0)
 
 
-def test_last_sync_watson_non_valid_json(watson):
+def test_last_sync_watson_non_valid_json(mock, watson):
     content = "{'foo': bar}"
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        with mock.patch('os.path.getsize', return_value=len(content)):
-            with pytest.raises(WatsonError):
-                watson.last_sync
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    mock.patch('os.path.getsize', return_value=len(content))
+    with pytest.raises(WatsonError):
+        watson.last_sync
 
 
-def test_last_sync_with_given_state(config_dir):
+def test_last_sync_with_given_state(config_dir, mock):
     content = json.dumps(123)
     now = arrow.now()
     watson = Watson(last_sync=now, config_dir=config_dir)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert watson.last_sync == now
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert watson.last_sync == now
 
 
-def test_last_sync_with_empty_given_state(config_dir):
+def test_last_sync_with_empty_given_state(config_dir, mock):
     content = json.dumps(123)
     watson = Watson(last_sync=None, config_dir=config_dir)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert watson.last_sync == arrow.get(0)
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert watson.last_sync == arrow.get(0)
 
 
 # frames
 
-def test_frames(watson):
+def test_frames(mock, watson):
     content = json.dumps([[0, 10, 'foo', None, ['A', 'B', 'C']]])
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert len(watson.frames) == 1
-        assert watson.frames[0].project == 'foo'
-        assert watson.frames[0].start == arrow.get(0)
-        assert watson.frames[0].stop == arrow.get(10)
-        assert watson.frames[0].tags == ['A', 'B', 'C']
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert len(watson.frames) == 1
+    assert watson.frames[0].project == 'foo'
+    assert watson.frames[0].start == arrow.get(0)
+    assert watson.frames[0].stop == arrow.get(10)
+    assert watson.frames[0].tags == ['A', 'B', 'C']
 
 
-def test_frames_without_tags(watson):
+def test_frames_without_tags(mock, watson):
     content = json.dumps([[0, 10, 'foo', None]])
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert len(watson.frames) == 1
-        assert watson.frames[0].project == 'foo'
-        assert watson.frames[0].start == arrow.get(0)
-        assert watson.frames[0].stop == arrow.get(10)
-        assert watson.frames[0].tags == []
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert len(watson.frames) == 1
+    assert watson.frames[0].project == 'foo'
+    assert watson.frames[0].start == arrow.get(0)
+    assert watson.frames[0].stop == arrow.get(10)
+    assert watson.frames[0].tags == []
 
 
-def test_frames_with_empty_file(watson):
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data="")):
-        with mock.patch('os.path.getsize', return_value=0):
-            assert len(watson.frames) == 0
+def test_frames_with_empty_file(mock, watson):
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=""))
+    mock.patch('os.path.getsize', return_value=0)
+    assert len(watson.frames) == 0
 
 
-def test_frames_with_nonexistent_file(watson):
-    with mock.patch('%s.open' % builtins, side_effect=IOError):
-        assert len(watson.frames) == 0
+def test_frames_with_nonexistent_file(mock, watson):
+    mock.patch('%s.open' % builtins, side_effect=IOError)
+    assert len(watson.frames) == 0
 
 
-def test_frames_watson_non_valid_json(watson):
+def test_frames_watson_non_valid_json(mock, watson):
     content = "{'foo': bar}"
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        with mock.patch('os.path.getsize') as mock_getsize:
-            mock_getsize.return_value(len(content))
-            with pytest.raises(WatsonError):
-                watson.frames
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    mock.patch('os.path.getsize', return_value=len(content))
+    with pytest.raises(WatsonError):
+        watson.frames
 
 
-def test_given_frames(config_dir):
+def test_given_frames(config_dir, mock):
     content = json.dumps([[0, 10, 'foo', None, ['A']]])
     watson = Watson(frames=[[0, 10, 'bar', None, ['A', 'B']]],
                     config_dir=config_dir)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert len(watson.frames) == 1
-        assert watson.frames[0].project == 'bar'
-        assert watson.frames[0].tags == ['A', 'B']
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert len(watson.frames) == 1
+    assert watson.frames[0].project == 'bar'
+    assert watson.frames[0].tags == ['A', 'B']
 
 
-def test_frames_with_empty_given_state(config_dir):
+def test_frames_with_empty_given_state(config_dir, mock):
     content = json.dumps([[0, 10, 'foo', None, ['A']]])
     watson = Watson(frames=[], config_dir=config_dir)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open(read_data=content)):
-        assert len(watson.frames) == 0
+    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    assert len(watson.frames) == 0
 
 
 # config
@@ -200,18 +194,18 @@ def test_empty_config_dir():
     assert watson._dir == get_app_dir('watson')
 
 
-def test_wrong_config(watson):
+def test_wrong_config(mock, watson):
     content = u"""
 toto
     """
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        with pytest.raises(ConfigurationError):
-            watson.config
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    with pytest.raises(ConfigurationError):
+        watson.config
 
 
-def test_empty_config(watson):
-    with mock.patch.object(ConfigParser, 'read', mock_read(u'')):
-        assert len(watson.config.sections()) == 0
+def test_empty_config(mock, watson):
+    mock.patch.object(ConfigParser, 'read', mock_read(u''))
+    assert len(watson.config.sections()) == 0
 
 
 # start
@@ -247,26 +241,26 @@ def test_start_two_projects(watson):
     assert watson.is_started is True
 
 
-def test_start_default_tags(watson):
+def test_start_default_tags(mock, watson):
     content = u"""
 [default_tags]
 my project = A B
     """
 
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        watson.start('my project')
-        assert watson.current['tags'] == ['A', 'B']
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    watson.start('my project')
+    assert watson.current['tags'] == ['A', 'B']
 
 
-def test_start_default_tags_with_supplementary_input_tags(watson):
+def test_start_default_tags_with_supplementary_input_tags(mock, watson):
     content = u"""
 [default_tags]
 my project = A B
     """
 
-    with mock.patch.object(ConfigParser, 'read', mock_read(content)):
-        watson.start('my project', tags=['C', 'D'])
-        assert watson.current['tags'] == ['C', 'D', 'A', 'B']
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    watson.start('my project', tags=['C', 'D'])
+    assert watson.current['tags'] == ['C', 'D', 'A', 'B']
 
 
 # stop
@@ -319,159 +313,159 @@ def test_cancel_no_project(watson):
 
 # save
 
-def test_save_without_changes(watson):
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+def test_save_without_changes(mock, watson):
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert not json_mock.called
+    assert not json_mock.called
 
 
-def test_save_current(watson):
+def test_save_current(mock, watson):
     watson.start('foo', ['A', 'B'])
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert json_mock.call_count == 1
-            result = json_mock.call_args[0][0]
-            assert result['project'] == 'foo'
-            assert isinstance(result['start'], (int, float))
-            assert result['tags'] == ['A', 'B']
+    assert json_mock.call_count == 1
+    result = json_mock.call_args[0][0]
+    assert result['project'] == 'foo'
+    assert isinstance(result['start'], (int, float))
+    assert result['tags'] == ['A', 'B']
 
 
-def test_save_current_without_tags(watson):
+def test_save_current_without_tags(mock, watson):
     watson.start('foo')
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert json_mock.call_count == 1
-            result = json_mock.call_args[0][0]
-            assert result['project'] == 'foo'
-            assert isinstance(result['start'], (int, float))
-            assert result['tags'] == []
+    assert json_mock.call_count == 1
+    result = json_mock.call_args[0][0]
+    assert result['project'] == 'foo'
+    assert isinstance(result['start'], (int, float))
+    assert result['tags'] == []
 
-            dump_args = json_mock.call_args[1]
-            assert dump_args['ensure_ascii'] is False
+    dump_args = json_mock.call_args[1]
+    assert dump_args['ensure_ascii'] is False
 
 
-def test_save_empty_current(config_dir):
+def test_save_empty_current(config_dir, mock):
     watson = Watson(current={'project': 'foo', 'start': 0},
                     config_dir=config_dir)
     watson.current = {}
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert json_mock.call_count == 1
-            result = json_mock.call_args[0][0]
-            assert result == {}
+    assert json_mock.call_count == 1
+    result = json_mock.call_args[0][0]
+    assert result == {}
 
 
-def test_save_frames_no_change(config_dir):
+def test_save_frames_no_change(config_dir, mock):
     watson = Watson(frames=[[0, 10, 'foo', None]],
                     config_dir=config_dir)
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert not json_mock.called
+    assert not json_mock.called
 
 
-def test_save_added_frame(config_dir):
+def test_save_added_frame(config_dir, mock):
     watson = Watson(frames=[[0, 10, 'foo', None]], config_dir=config_dir)
     watson.frames.add('bar', 10, 20, ['A'])
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert json_mock.call_count == 1
-            result = json_mock.call_args[0][0]
-            assert len(result) == 2
-            assert result[0][2] == 'foo'
-            assert result[0][4] == []
-            assert result[1][2] == 'bar'
-            assert result[1][4] == ['A']
+    assert json_mock.call_count == 1
+    result = json_mock.call_args[0][0]
+    assert len(result) == 2
+    assert result[0][2] == 'foo'
+    assert result[0][4] == []
+    assert result[1][2] == 'bar'
+    assert result[1][4] == ['A']
 
 
-def test_save_changed_frame(config_dir):
+def test_save_changed_frame(config_dir, mock):
     watson = Watson(frames=[[0, 10, 'foo', None, ['A']]],
                     config_dir=config_dir)
     watson.frames[0] = ('bar', 0, 10, ['A', 'B'])
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert json_mock.call_count == 1
-            result = json_mock.call_args[0][0]
-            assert len(result) == 1
-            assert result[0][2] == 'bar'
-            assert result[0][4] == ['A', 'B']
+    assert json_mock.call_count == 1
+    result = json_mock.call_args[0][0]
+    assert len(result) == 1
+    assert result[0][2] == 'bar'
+    assert result[0][4] == ['A', 'B']
 
-            dump_args = json_mock.call_args[1]
-            assert dump_args['ensure_ascii'] is False
-
-
-def test_save_config_no_changes(watson):
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch.object(ConfigParser, 'write') as write_mock:
-            watson.save()
-
-            assert not write_mock.called
+    dump_args = json_mock.call_args[1]
+    assert dump_args['ensure_ascii'] is False
 
 
-def test_save_config(watson):
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch.object(ConfigParser, 'write') as write_mock:
-            watson.config = ConfigParser()
-            watson.save()
+def test_save_config_no_changes(mock, watson):
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    write_mock = mock.patch.object(ConfigParser, 'write')
+    watson.save()
 
-            assert write_mock.call_count == 1
+    assert not write_mock.called
 
 
-def test_save_last_sync(watson):
+def test_save_config(mock, watson):
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    write_mock = mock.patch.object(ConfigParser, 'write')
+    watson.config = ConfigParser()
+    watson.save()
+
+    assert write_mock.call_count == 1
+
+
+def test_save_last_sync(mock, watson):
     now = arrow.now()
     watson.last_sync = now
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert json_mock.call_count == 1
-            assert json_mock.call_args[0][0] == now.timestamp
+    assert json_mock.call_count == 1
+    assert json_mock.call_args[0][0] == now.timestamp
 
 
-def test_save_empty_last_sync(config_dir):
+def test_save_empty_last_sync(config_dir, mock):
     watson = Watson(last_sync=arrow.now(), config_dir=config_dir)
     watson.last_sync = None
 
-    with mock.patch('%s.open' % builtins, mock.mock_open()):
-        with mock.patch('json.dump') as json_mock:
-            watson.save()
+    mock.patch('%s.open' % builtins, mock.mock_open())
+    json_mock = mock.patch('json.dump')
+    watson.save()
 
-            assert json_mock.call_count == 1
-            assert json_mock.call_args[0][0] == 0
+    assert json_mock.call_count == 1
+    assert json_mock.call_args[0][0] == 0
 
 
-def test_watson_save_calls_safe_save(watson, config_dir):
+def test_watson_save_calls_safe_save(mock, config_dir, watson):
     frames_file = os.path.join(config_dir, 'frames')
     watson.start('foo', tags=['A', 'B'])
     watson.stop()
 
-    with mock.patch('watson.watson.safe_save') as save_mock:
-        watson.save()
+    save_mock = mock.patch('watson.watson.safe_save')
+    watson.save()
 
-        assert watson._frames.changed
-        assert save_mock.call_count == 1
-        assert len(save_mock.call_args[0]) == 2
-        assert save_mock.call_args[0][0] == frames_file
+    assert watson._frames.changed
+    assert save_mock.call_count == 1
+    assert len(save_mock.call_args[0]) == 2
+    assert save_mock.call_args[0][0] == frames_file
 
 
 # push
@@ -504,7 +498,7 @@ def test_push_with_no_token(watson):
         watson.push(arrow.now())
 
 
-def test_push(watson, monkeypatch):
+def test_push(mock, watson):
     config = ConfigParser()
     config.add_section('backend')
     config.set('backend', 'url', 'http://foo.com')
@@ -523,7 +517,7 @@ def test_push(watson, monkeypatch):
     watson.frames.add('foo', 1, 2)
     watson.frames.add('bar', 3, 4)
 
-    monkeypatch.setattr(watson, '_get_remote_projects', lambda *args: [
+    mock.patch.object(watson, '_get_remote_projects', return_value=[
         {'name': 'foo', 'url': '/projects/1/'},
         {'name': 'bar', 'url': '/projects/2/'},
         {'name': 'lol', 'url': '/projects/3/'},
@@ -533,32 +527,28 @@ def test_push(watson, monkeypatch):
         def __init__(self):
             self.status_code = 201
 
-    with mock.patch('requests.post') as mock_put:
-        mock_put.return_value = Response()
+    mock_put = mock.patch('requests.post', return_value=Response())
+    mock.patch.object(Watson, 'config', new_callable=mock.PropertyMock,
+                      return_value=config)
+    watson.push(last_pull)
 
-        with mock.patch.object(
-                Watson, 'config', new_callable=mock.PropertyMock
-                ) as mock_config:
-            mock_config.return_value = config
-            watson.push(last_pull)
+    requests.post.assert_called_once_with(
+        mock.ANY,
+        mock.ANY,
+        headers={
+            'content-type': 'application/json',
+            'Authorization': "Token " + config.get('backend', 'token')
+        }
+    )
 
-        requests.post.assert_called_once_with(
-            mock.ANY,
-            mock.ANY,
-            headers={
-                'content-type': 'application/json',
-                'Authorization': "Token " + config.get('backend', 'token')
-            }
-        )
+    frames_sent = json.loads(mock_put.call_args[0][1])
+    assert len(frames_sent) == 2
 
-        frames_sent = json.loads(mock_put.call_args[0][1])
-        assert len(frames_sent) == 2
+    assert frames_sent[0].get('project') == '/projects/2/'
+    assert frames_sent[0].get('tags') == ['A', 'B']
 
-        assert frames_sent[0].get('project') == '/projects/2/'
-        assert frames_sent[0].get('tags') == ['A', 'B']
-
-        assert frames_sent[1].get('project') == '/projects/3/'
-        assert frames_sent[1].get('tags') == []
+    assert frames_sent[1].get('project') == '/projects/3/'
+    assert frames_sent[1].get('tags') == []
 
 
 # pull
@@ -591,7 +581,7 @@ def test_pull_with_no_token(watson):
         watson.pull()
 
 
-def test_pull(watson, monkeypatch):
+def test_pull(mock, watson):
     config = ConfigParser()
     config.add_section('backend')
     config.set('backend', 'url', 'http://foo.com')
@@ -601,7 +591,7 @@ def test_pull(watson, monkeypatch):
 
     watson.frames.add('foo', 1, 2, ['A', 'B'], id='1')
 
-    monkeypatch.setattr(watson, '_get_remote_projects', lambda *args: [
+    mock.patch.object(watson, '_get_remote_projects', return_value=[
         {'name': 'foo', 'url': '/projects/1/'},
         {'name': 'bar', 'url': '/projects/2/'},
     ])
@@ -618,23 +608,19 @@ def test_pull(watson, monkeypatch):
                  'tags': []}
             ]
 
-    with mock.patch('requests.get') as mock_get:
-        mock_get.return_value = Response()
+    mock.patch('requests.get', return_value=Response())
+    mock.patch.object(Watson, 'config', new_callable=mock.PropertyMock,
+                      return_value=config)
+    watson.pull()
 
-        with mock.patch.object(
-                Watson, 'config', new_callable=mock.PropertyMock
-                ) as mock_config:
-            mock_config.return_value = config
-            watson.pull()
-
-        requests.get.assert_called_once_with(
-            mock.ANY,
-            params={'last_sync': watson.last_sync},
-            headers={
-                'content-type': 'application/json',
-                'Authorization': "Token " + config.get('backend', 'token')
-            }
-        )
+    requests.get.assert_called_once_with(
+        mock.ANY,
+        params={'last_sync': watson.last_sync},
+        headers={
+            'content-type': 'application/json',
+            'Authorization': "Token " + config.get('backend', 'token')
+        }
+    )
 
     assert len(watson.frames) == 2
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,11 @@ envlist = flake8,py27,py33,py34,py35
 skip_missing_interpreters = True
 
 [testenv]
-deps = pytest
+deps = py
+    pytest
     mock
     pytest-datafiles
+    pytest-mock
 commands = py.test -vs tests/
 usedevelop = True
 


### PR DESCRIPTION
The existing tests where all in one file and this was getting way too long.

So I put tests for the the `watson.config` and `watson.utils` modules into their own `test_*.py` files and created a `conftest.py` file for the test fixtures and put some test utility functions in a `__init__.py`module for the `test` package dir.

I also changed the tests to use the `mock` fixture provided py `pytest-mock`. This makes the tests easier to read and safeguards against patching side-effects without having to use `with` everywhere. Lastly, I redefined the `_dt` helper function used in `test_utils.py` using `functools.partial` to save some repetition.

Signed-off-by: Christopher Arndt chris@chrisarndt.de
