### PR TITLE
Make formatting styles configurable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 arrow
-click
+click>=5.0
 requests

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -144,6 +144,21 @@ value5 = one
         "Modifying default return value should not have side effect.")
 
 
+def test_config_getitems(mock, watson):
+    content = """
+[test1]
+foo=bar
+spamm=eggs
+
+[test2]
+"""
+    mock.patch.object(ConfigParser, 'read', mock_read(content))
+    assert watson.config.getitems('test1') == dict(foo='bar', spamm='eggs')
+    assert watson.config.getitems('test2') == {}
+    assert watson.config.getitems('bogus') == {}
+    assert watson.config.getitems('bogus', 'default') == 'default'
+
+
 def test_set_config(watson):
     config = ConfigParser()
     config.set('foo', 'bar', 'lol')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,7 +79,6 @@ value2 = 42
 value3 = spamm
 value4 =
     """
-
     mock.patch.object(ConfigParser, 'read', mock_read(content))
     config = watson.config
     assert config.getfloat('options', 'value1') == 3.14

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -151,9 +151,9 @@ def test_style_no_context(element, expected):
 ])
 def test_style_with_context(element, expected, mock):
     content = u"""
-[style_project]
+[style:project]
 fg = green
-[style_tag]
+[style:tag]
 fg = yellow
     """
     mock.patch.object(ConfigParser, 'read', mock_read(content))

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 
+
 import py
 import pytest
 import requests

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -14,9 +14,9 @@ import click
 
 from . import watson as _watson
 from .frames import Frame
-from .utils import (format_timedelta, get_frame_from_argument,
-                    get_start_time_for_period, options, safe_save,
-                    sorted_groupby, style)
+from .utils import (format_tags, format_short_id, format_timedelta,
+                    get_frame_from_argument, get_start_time_for_period,
+                    options, safe_save, sorted_groupby, style)
 
 
 class MutuallyExclusiveOption(click.Option):
@@ -106,7 +106,7 @@ def _start(watson, project, tags, restart=False):
     current = watson.start(project, tags, restart=restart)
     click.echo("Starting project {} {} at {}".format(
         style('project', project),
-        style('tags', current['tags']),
+        format_tags(current['tags']),
         style('time', "{:HH:mm}".format(current['start']))
     ))
     watson.save()
@@ -169,9 +169,9 @@ def stop(watson):
     frame = watson.stop()
     click.echo("Stopping project {} {}, started {}. (id: {})".format(
         style('project', frame.project),
-        style('tags', frame.tags),
+        format_tags(frame.tags),
         style('time', frame.start.humanize()),
-        style('short_id', frame.id)
+        format_short_id(frame.id)
     ))
     watson.save()
 
@@ -226,7 +226,7 @@ def restart(ctx, watson, frame, stop_):
             raise click.ClickException("{} {} {}".format(
                 style('error', "Project already started:"),
                 style('project', watson.current['project']),
-                style('tags', watson.current['tags'])))
+                format_tags(watson.current['tags'])))
 
     frame = get_frame_from_argument(watson, frame)
 
@@ -243,7 +243,7 @@ def cancel(watson):
     old = watson.cancel()
     click.echo("Canceling the timer for project {} {}".format(
         style('project', old['project']),
-        style('tags', old['tags'])
+        format_tags(old['tags'])
     ))
     watson.save()
 
@@ -279,7 +279,7 @@ def status(watson):
     timefmt = watson.config.get('options', 'time_format', '%H:%M:%S%z')
     click.echo("Project {} {} started {} ({} {})".format(
         style('project', current['project']),
-        style('tags', current['tags']),
+        format_tags(current['tags']),
         style('time', current['start'].humanize()),
         style('date', current['start'].strftime(datefmt)),
         style('time', current['start'].strftime(timefmt))
@@ -589,10 +589,10 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day):
                 project=style('project',
                               '{:>{}}'.format(frame.project, longest_project)),
                 pad=longest_project,
-                tags=style('tags', frame.tags),
+                tags=format_tags(frame.tags),
                 start=style('time', '{:HH:mm}'.format(frame.start)),
                 stop=style('time', '{:HH:mm}'.format(frame.stop)),
-                id=style('short_id', frame.id)
+                id=format_short_id(frame.id)
             )
             for frame in frames
         ))
@@ -662,7 +662,7 @@ def frames(watson):
     [...]
     """
     for frame in watson.frames:
-        click.echo(style('short_id', frame.id))
+        click.echo(format_short_id(frame.id))
 
 
 @cli.command(context_settings={'ignore_unknown_options': True})
@@ -742,7 +742,7 @@ def edit(watson, id):
         '({delta})'.format(
             delta=format_timedelta(stop - start) if stop else '-',
             project=style('project', project),
-            tags=style('tags', tags),
+            tags=format_tags(tags),
             start=style(
                 'time',
                 start.to(local_tz).format(time_format)
@@ -773,7 +773,7 @@ def remove(watson, id, force):
             "You are about to remove frame "
             "{project} {tags} from {start} to {stop}, continue?".format(
                 project=style('project', frame.project),
-                tags=style('tags', frame.tags),
+                tags=format_tags(frame.tags),
                 start=style('time', '{:HH:mm}'.format(frame.start)),
                 stop=style('time', '{:HH:mm}'.format(frame.stop))
             ),
@@ -986,7 +986,7 @@ def merge(watson, frames_with_conflict, force):
             'stop': original_frame.stop.format(date_format),
             'tags': original_frame.tags
         }
-        click.echo("frame {}:".format(style('short_id', original_frame.id)))
+        click.echo("frame {}:".format(format_short_id(original_frame.id)))
         click.echo("{}".format('\n'.join('<' + line for line in json.dumps(
             original_frame_data, indent=4, ensure_ascii=False).splitlines())))
         click.echo("---")

--- a/watson/config.py
+++ b/watson/config.py
@@ -4,9 +4,9 @@
 import shlex
 
 try:
-    from configparser import RawConfigParser
+    from configparser import NoSectionError, RawConfigParser
 except ImportError:
-    from ConfigParser import RawConfigParser
+    from ConfigParser import NoSectionError, RawConfigParser
 
 __all__ = ('ConfigParser',)
 
@@ -98,6 +98,17 @@ class ConfigParser(RawConfigParser):
                     for item in value.splitlines() if item.strip()]
         else:
             return shlex.split(value)
+
+    def getitems(self, section, default=None):
+        """Return the option/value pairs of the given section as a dictionary.
+
+        If section does not exist, return default (defaults to an empty dict).
+
+        """
+        try:
+            return dict(self.items(section))
+        except NoSectionError:
+            return {} if default is None else default
 
     def set(self, section, option, value):
         """

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -17,36 +17,39 @@ except NameError:
     text_type = str
 
 
+DEFAULT_STYLES = {
+    'project': {'fg': 'magenta'},
+    'tag': {'fg': 'blue'},
+    'time': {'fg': 'green'},
+    'error': {'fg': 'red'},
+    'date': {'fg': 'cyan'},
+    'id': {'fg': 'white'}
+}
+
+
+def format_short_id(id):
+    return style('id', id[:7])
+
+
+def format_tags(tags):
+    if not tags:
+        return ''
+
+    return '[{}]'.format(', '.join(
+        style('tag', tag) for tag in tags
+    ))
+
+
 def style(name, element):
-    def _style_tags(tags):
-        if not tags:
-            return ''
+    style = DEFAULT_STYLES.get(name, {})
+    try:
+        config = click.get_current_context().obj.config
+        style = style.copy()  # take care not change the default styles
+        style.update(config.getitems('style_%s' % name))
+    except (AttributeError, RuntimeError):
+        pass
 
-        return '[{}]'.format(', '.join(
-            style('tag', tag) for tag in tags
-        ))
-
-    def _style_short_id(id):
-        return style('id', id[:7])
-
-    formats = {
-        'project': {'fg': 'magenta'},
-        'tags': _style_tags,
-        'tag': {'fg': 'blue'},
-        'time': {'fg': 'green'},
-        'error': {'fg': 'red'},
-        'date': {'fg': 'cyan'},
-        'short_id': _style_short_id,
-        'id': {'fg': 'white'}
-    }
-
-    fmt = formats.get(name, {})
-
-    if isinstance(fmt, dict):
-        return click.style(element, **fmt)
-    else:
-        # The fmt might be a function if we need to do some computation
-        return fmt(element)
+    return click.style(element, **style)
 
 
 def format_timedelta(delta):

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -45,7 +45,7 @@ def style(name, element):
     try:
         config = click.get_current_context().obj.config
         style = style.copy()  # take care not change the default styles
-        style.update(config.getitems('style_%s' % name))
+        style.update(config.getitems('style:%s' % name))
     except (AttributeError, RuntimeError):
         pass
 


### PR DESCRIPTION
Styles can be set via sections in the config file named `style:<element>`, where `<element>` is the name of an element a style can be applied to. Settings in that section are used as parameters to the `click.style` function.

The current list of possible elements is:

- project
- tag
- time
- error
- date
- id

Example config:

```
[style:project]
fg = white
bg = black

[style:tag]
fg = yellow
bg = white
```

Notes:
- This PR depends on PR #139 
- Documentation is not updated yet, it will be added when the reviewers agree this is a good config structure and implementation.
- I had originally contemplated to use a config structure as shown below or similar, but it would have made the config parsing much more complicated.

```
[styles]
project = fg:white bg:black
tag = fg:red
...
```
