### PR TITLE
[WIP] Print log to terminal if option selected or if not much text

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -171,6 +171,7 @@ Flag | Help
 `-d, --day` | Reports activity for the current day.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`--terminal` | Print to the terminal.
 `--help` | Show this message and exit.
 
 ## `merge`

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -607,7 +607,14 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day):
             for frame in frames
         ))
 
-    click.echo_via_pager('\n'.join(lines))
+    num_term_rows, _ = [int(i)
+                        for i in os.popen('stty size', 'r').read().split()]
+    num_rows = len(watson.frames.dump()) + (len(lines)+1) / 3 * 2 - 1
+
+    if num_term_rows > num_rows:
+        click.echo('\n'.join(lines))
+    else:
+        click.echo_via_pager('\n'.join(lines))
 
 
 @cli.command()

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -502,8 +502,11 @@ def report(watson, current, from_, to, projects,
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
+@click.option('--terminal', 'print_to_term', is_flag=True,
+              help="Print to the terminal.")
 @click.pass_obj
-def log(watson, current, from_, to, projects, tags, year, month, week, day):
+def log(watson, current, from_, to, projects, tags, year, month, week, day,
+        print_to_term):
     """
     Display each recorded session during the given timespan.
 
@@ -611,7 +614,7 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day):
                         for i in os.popen('stty size', 'r').read().split()]
     num_rows = len(watson.frames.dump()) + (len(lines)+1) / 3 * 2 - 1
 
-    if num_term_rows > num_rows:
+    if print_to_term or num_term_rows > num_rows:
         click.echo('\n'.join(lines))
     else:
         click.echo_via_pager('\n'.join(lines))


### PR DESCRIPTION
The way Watson currently behaves it's quite difficult to edit frames by hash: to get the hash of a frame AND enough context to figure out what that frame is about you have to type in 'watson log'; but this brings up a pager and when you close this pager all of the log information vanishes, making it hard to remember the hash number to do a 'watson edit hash_here'.

It would be much easier if there was an option to print the log to the terminal. So I added this option. I also made it so that if the log text can fit in the terminal window, then it should print to the terminal (not the pager); this is how 'git log' works.

To determine the terminal size I used the 'stty size' command over a popen, as recommended here: https://stackoverflow.com/questions/566746/how-to-get-linux-console-window-width-in-python. Apparently this command is widely supported.