### PR TITLE
Fix watson config command

### DIFF
--- a/watson/cli.py
+++ b/watson/cli.py
@@ -868,6 +868,7 @@ def config(context, key, value, edit):
             wconfig.add_section(section)
 
         wconfig.set(section, option, value)
+        watson.config = wconfig
         watson.save()
 
 


### PR DESCRIPTION
New configuration was never saved on disk.

Follow up of #159 & #158