### PR TITLE
Add --json option to log command

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -171,6 +171,7 @@ Flag | Help
 `-d, --day` | Reports activity for the current day.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-j, --json` | Format the log in JSON instead of plain text
 `--help` | Show this message and exit.
 
 ## `merge`

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -583,50 +583,50 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
             for frame in filtered_frames
         ]
         click.echo(json.dumps(log, indent=4, sort_keys=True))
-    else:
-        frames_by_day = sorted_groupby(
-            filtered_frames,
-            operator.attrgetter('day'), reverse=True
+        return
+
+    frames_by_day = sorted_groupby(
+        filtered_frames,
+        operator.attrgetter('day'), reverse=True
+    )
+
+    lines = []
+
+    for i, (day, frames) in enumerate(frames_by_day):
+        if i != 0:
+            lines.append('')
+
+        frames = sorted(frames, key=operator.attrgetter('start'))
+        longest_project = max(len(frame.project) for frame in frames)
+
+        daily_total = reduce(
+            operator.add,
+            (frame.stop - frame.start for frame in frames)
         )
 
-        lines = []
-
-        for i, (day, frames) in enumerate(frames_by_day):
-            if i != 0:
-                lines.append('')
-
-            frames = sorted(frames, key=operator.attrgetter('start'))
-            longest_project = max(len(frame.project) for frame in frames)
-
-            daily_total = reduce(
-                operator.add,
-                (frame.stop - frame.start for frame in frames)
-            )
-
-            lines.append(
-                style(
-                    'date', "{:dddd DD MMMM YYYY} ({})".format(
-                        day, format_timedelta(daily_total)
-                    )
+        lines.append(
+            style(
+                'date', "{:dddd DD MMMM YYYY} ({})".format(
+                    day, format_timedelta(daily_total)
                 )
             )
-            frame_format = (
-                '\t{id}  {start} to {stop}  {delta:>11}  {project}  {tags}')
-            lines.append('\n'.join(
-                frame_format.format(
-                    delta=format_timedelta(frame.stop - frame.start),
-                    project=style('project',
-                                  '{:>{}}'.format(
-                                      frame.project, longest_project)),
-                    pad=longest_project,
-                    tags=style('tags', frame.tags),
-                    start=style('time', '{:HH:mm}'.format(frame.start)),
-                    stop=style('time', '{:HH:mm}'.format(frame.stop)),
-                    id=style('short_id', frame.id)
-                )
-                for frame in frames
-            ))
-            click.echo_via_pager('\n'.join(lines))
+        )
+
+        lines.append('\n'.join(
+            '\t{id}  {start} to {stop}  {delta:>11}  {project}  {tags}'.format(
+                delta=format_timedelta(frame.stop - frame.start),
+                project=style('project',
+                              '{:>{}}'.format(frame.project, longest_project)),
+                pad=longest_project,
+                tags=style('tags', frame.tags),
+                start=style('time', '{:HH:mm}'.format(frame.start)),
+                stop=style('time', '{:HH:mm}'.format(frame.stop)),
+                id=style('short_id', frame.id)
+            )
+            for frame in frames
+        ))
+
+    click.echo_via_pager('\n'.join(lines))
 
 
 @cli.command()


### PR DESCRIPTION
Similar to `report --json`, this makes it easier to integrate Watson with other tools.

Example output:
```json
[
    {
        "id": "9acb66330c8a41fe96a86247d2457f84",
        "project": "myproject",
        "start": "2017-08-22T07:51:00+08:00",
        "stop": "2017-08-22T08:05:17+08:00",
        "tags": [
            "dev"
        ]
    },
    {
        "id": "a06a547e546848cd90253994836b45f3",
        "project": "myproject",
        "start": "2017-08-22T11:00:05+08:00",
        "stop": "2017-08-22T11:12:09+08:00",
        "tags": [
            "invoicing"
        ]
    }
]
```

I had to tweak the existing code a little to stay within the flake8 line limit.