### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def parse_requirements(requirements, ignore=('setuptools',)):
             pkg = line.strip()
             if pkg not in ignore:
                 packages.add(pkg)
-        return packages
+        return tuple(packages)
 
 
 setup(

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -183,7 +183,7 @@ def safe_save(path, content, ext='.bak'):
                 tmpfp.write(content)
             else:
                 content(tmpfp)
-    except:
+    except Exception:
         try:
             os.unlink(tmpfp.name)
         except (IOError, OSError):


### PR DESCRIPTION
Tried to install the project (`pip install -e .`) and it broke with the following error:

> 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed

This pull request is a one-line change to return the requirements as a tuple rather than a set, and thus allow the project to install.

I'm on Python 3.6.3 on Windows 10 x64.