### PR TITLE
Coloured log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 This document records all notable changes to Watson. This project adheres to
 [Semantic Versioning](http://semver.org/).
 
+* Added: the `report` and `log` commands' output can no selectively be run
+  through a pager.
+
 ## 1.5.2 (2017-08-02)
 
 * Fixed: Follow up on the `config` command fix (#161)

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -128,7 +128,7 @@ and `--year`, `--month` and `--week` to the current year, month or week
 respectively.
 
 If you are outputting to the terminal, you can selectively enable a pager
-through the `--pager`` option.
+through the `--pager` option.
 
 You can limit the log to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
@@ -177,7 +177,7 @@ Flag | Help
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `-j, --json` | Format the log in JSON instead of plain text
-`-v, --pager / -V, --no-pager` | (Don't) view output through a pager.
+`-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
 
 ## `merge`
@@ -334,7 +334,7 @@ You can limit the report to a project or a tag using the `--project` and
 projects or tags to the report.
 
 If you are outputting to the terminal, you can selectively enable a pager
-through the `--pager`` option.
+through the `--pager` option.
 
 You can change the output format for the report from *plain text* to *JSON*
 by using the `--json` option.
@@ -420,7 +420,7 @@ Flag | Help
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `-j, --json` | Format the report in JSON instead of plain text
-`-v, --pager / -V, --no-pager` | (Don't) view output through a pager.
+`-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
 
 ## `restart`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -127,6 +127,9 @@ You can also use special shortcut options for easier timespan control:
 and `--year`, `--month` and `--week` to the current year, month or week
 respectively.
 
+If you are outputting to the terminal, you can selectively enable a pager
+through the `--pager`` option.
+
 You can limit the log to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the log.
@@ -174,6 +177,7 @@ Flag | Help
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `-j, --json` | Format the log in JSON instead of plain text
+`-v, --pager / -V, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
 
 ## `merge`
@@ -329,6 +333,9 @@ You can limit the report to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the report.
 
+If you are outputting to the terminal, you can selectively enable a pager
+through the `--pager`` option.
+
 You can change the output format for the report from *plain text* to *JSON*
 by using the `--json` option.
 
@@ -413,6 +420,7 @@ Flag | Help
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `-j, --json` | Format the report in JSON instead of plain text
+`-v, --pager / -V, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
 
 ## `restart`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -108,8 +108,8 @@ with the `-c/-C` resp. `--current/--no-current` flags.
 
 If `true` (or not set), the output of the `log` and `report` command will be
 run through a pager by default. The option can be overridden on the command
-line with the `-v/-V` or `--pager/--no-pager` flags. If other commands output
-in colour, but `log` or `report` does not, try disabling the pager.
+line with the `-g/-G` or `--pager/--no-pager` flags. If other commands output
+in colour, but `log` or `report` do not, try disabling the pager.
 
 #### `options.report_current`
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -104,6 +104,13 @@ If `true`, the output of the `log` command will include the currently running
 frame (if any) by default. The option can be overridden on the command line
 with the `-c/-C` resp. `--current/--no-current` flags.
 
+#### `options.log_pager`
+
+If `true` (or not set), the output of the `log` command will be run through a
+pager by default. The option can be overridden on the command line
+with the `--pager/--no-pager` flags. If other commands output in colour, but
+`log` does not, try disabling the pager.
+
 #### `options.report_current`
 
 If `true`, the output of the `report` command will include the currently
@@ -205,6 +212,7 @@ stop_on_restart = false
 date_format = %Y.%m.%d
 time_format = %H:%M:%S%z
 log_current = false
+log_pager = true
 report_current = false
 ```
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -104,12 +104,12 @@ If `true`, the output of the `log` command will include the currently running
 frame (if any) by default. The option can be overridden on the command line
 with the `-c/-C` resp. `--current/--no-current` flags.
 
-#### `options.log_pager`
+#### `options.pager`
 
-If `true` (or not set), the output of the `log` command will be run through a
-pager by default. The option can be overridden on the command line
-with the `--pager/--no-pager` flags. If other commands output in colour, but
-`log` does not, try disabling the pager.
+If `true` (or not set), the output of the `log` and `report` command will be
+run through a pager by default. The option can be overridden on the command
+line with the `-v/-V` or `--pager/--no-pager` flags. If other commands output
+in colour, but `log` or `report` does not, try disabling the pager.
 
 #### `options.report_current`
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -352,7 +352,7 @@ _SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
               "times")
 @click.option('-j', '--json', 'format_json', is_flag=True,
               help="Format the report in JSON instead of plain text")
-@click.option('-v/-V', '--pager/--no-pager', 'pager', default=None,
+@click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 def report(watson, current, from_, to, projects,
@@ -377,7 +377,7 @@ def report(watson, current, from_, to, projects,
     projects or tags to the report.
 
     If you are outputting to the terminal, you can selectively enable a pager
-    through the `--pager`` option.
+    through the `--pager` option.
 
     You can change the output format for the report from *plain text* to *JSON*
     by using the `--json` option.
@@ -462,14 +462,20 @@ def report(watson, current, from_, to, projects,
     lines = []
     # use the pager, or print directly to the terminal
     if pager or (pager is None and
-            watson.config.getboolean('options', 'pager')):
-        use_pager = True
+                 watson.config.getboolean('options', 'pager', True)):
+
         def _print(line):
             lines.append(line)
+
+        def _final_print(lines):
+            click.echo_via_pager('\n'.join(lines))
     else:
-        use_pager = False
+
         def _print(line):
             click.echo(line)
+
+        def _final_print(lines):
+            pass
 
     _print('{} -> {}\n'.format(
         style('date', '{:ddd DD MMMM YYYY}'.format(
@@ -478,7 +484,7 @@ def report(watson, current, from_, to, projects,
         style('date', '{:ddd DD MMMM YYYY}'.format(
             arrow.get(report['timespan']['to'])
         ))
-        ))
+    ))
 
     projects = report['projects']
     for project in projects:
@@ -511,8 +517,7 @@ def report(watson, current, from_, to, projects,
             )))
         ))
 
-    if use_pager:
-        click.echo_via_pager('\n'.join(lines))
+    _final_print(lines)
 
 
 @cli.command()
@@ -550,7 +555,7 @@ def report(watson, current, from_, to, projects,
               "times")
 @click.option('-j', '--json', 'format_json', is_flag=True,
               help="Format the log in JSON instead of plain text")
-@click.option('-v/-V', '--pager/--no-pager', 'pager', default=None,
+@click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 def log(watson, current, from_, to, projects, tags, year, month, week, day,
@@ -568,7 +573,7 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
     respectively.
 
     If you are outputting to the terminal, you can selectively enable a pager
-    through the `--pager`` option.
+    through the `--pager` option.
 
     You can limit the log to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
@@ -644,14 +649,20 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
     lines = []
     # use the pager, or print directly to the terminal
     if pager or (pager is None and
-            watson.config.getboolean('options', 'pager')):
-        use_pager = True
+                 watson.config.getboolean('options', 'pager', True)):
+
         def _print(line):
             lines.append(line)
+
+        def _final_print(lines):
+            click.echo_via_pager('\n'.join(lines))
     else:
-        use_pager = False
+
         def _print(line):
             click.echo(line)
+
+        def _final_print(lines):
+            pass
 
     for i, (day, frames) in enumerate(frames_by_day):
         if i != 0:
@@ -686,8 +697,7 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
             for frame in frames
         ))
 
-    if use_pager:
-        click.echo_via_pager('\n'.join(lines))
+    _final_print(lines)
 
 
 @cli.command()

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -529,9 +529,11 @@ def report(watson, current, from_, to, projects,
               "times")
 @click.option('-j', '--json', 'format_json', is_flag=True,
               help="Format the log in JSON instead of plain text")
+@click.option('--pager/--no-pager', 'pager', default=None,
+              help="(Don't) run output through a pager.")
 @click.pass_obj
 def log(watson, current, from_, to, projects, tags, year, month, week, day,
-        format_json):
+        format_json, pager):
     """
     Display each recorded session during the given timespan.
 
@@ -650,7 +652,12 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
             for frame in frames
         ))
 
-    click.echo_via_pager('\n'.join(lines))
+    if pager or (pager is None and
+                 watson.config.getboolean('options', 'log_pager',
+                                          default=True)):
+        click.echo_via_pager('\n'.join(lines))
+    else:
+        click.echo('\n'.join(lines))
 
 
 @cli.command()


### PR DESCRIPTION
At least on Windows `click.echo_through_pager()` seems to eat the ANSI colour codes. This PR "fixes" that by allowing the pager to be bypassed and use the "regular" `click.echo()` (which displays colour codes fine). It does this by adding a `--pager/--no-pager` option to the *log* sub-command, and a corresponding `options.log_pager` configuration setting.

![image](https://user-images.githubusercontent.com/1548809/33798713-e00d6340-dcda-11e7-9871-8f58c1a4527e.png)

It also makes a couple other small changes:

- requires/includes PR #175 (I can't install *watson* otherwise...)
- changes the formatting slightly of the log's daily heading to better match other output
- removes an extra space that is displayed several places is a frame has no corresponding tags.

An issue has been submitted upstream to click (see https://github.com/pallets/click/issues/901) but this seems like a practical work-around.

Also, the main image on the [first page of the documentation](https://tailordev.github.io/Watson/) should be updated. It purportedly demonstrates the *report* sub-command, but the output looks like it's actually the *log* sub-command.

Thirdly, is there a comprehensive list of configuration file settings somewhere in the documentation?

Lastly, thanks for making *watson*; I'm super excited to have discovered it!