### PR TITLE
Standarize formatting of `log`'s daily header line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def parse_requirements(requirements, ignore=('setuptools',)):
             pkg = line.strip()
             if pkg not in ignore:
                 packages.add(pkg)
-        return packages
+        return tuple(packages)
 
 
 setup(

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -630,10 +630,9 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
         )
 
         lines.append(
-            style(
-                'date', "{:dddd DD MMMM YYYY} ({})".format(
-                    day, format_timedelta(daily_total)
-                )
+            "{date} ({daily_total})".format(
+                date=style('date', "{:dddd DD MMMM YYYY}".format(day)),
+                daily_total=style('time', format_timedelta(daily_total))
             )
         )
 


### PR DESCRIPTION
Rather than making the header all one colour, this makes it so the date part is highlighted like a date, and the times are highlighted like times elsewhere.

Broken off of #176