### PR TITLE
add conditional dependicies for older versions of Python on tox

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-arrow<0.11.0
+arrow!=0.11,!=0.12
 click
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,11 @@ envlist = flake8,py27,py33,py34,py35,py36
 skip_missing_interpreters = True
 
 [testenv]
-deps = py
-    pytest<=3.2.5
+deps =
+    ; pytest 3.3.0 dropped support for Python 3.3
+    py33: pytest<=3.2.5
+    py27,py34,py35,py36: pytest
+    py
     mock
     pytest-datafiles
     pytest-mock


### PR DESCRIPTION
Requirements vary slightly between different version of Python. This allows tox to deal with that.