### PR TITLE
For report and log, allow specifying a timeperiod of "all"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This document records all notable changes to Watson. This project adheres to
   options to only output the selected information (#166).
 * Added: the `report` and `log` commands' output can now selectively be run
   through a pager (#176).
+* Added: the `report` and `log` commands now take an `--all` option to output
+  all recorded frames (#185).
 * Updated: when renaming a project or tag, the `updated_at` timestamp is
   updated on all affected frames (#181).
 * Updated: some enhancements and formatting fixes have been done to the output

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -174,6 +174,7 @@ Flag | Help
 `-m, --month` | Reports activity for the current month.
 `-w, --week` | Reports activity for the current week.
 `-d, --day` | Reports activity for the current day.
+`-a, --all` | Reports all activities.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `-j, --json` | Format the log in JSON instead of plain text
@@ -381,7 +382,7 @@ Example:
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
     
-    $ watson report --format json
+    $ watson report --json
     {
         "projects": [
             {
@@ -417,6 +418,7 @@ Flag | Help
 `-m, --month` | Reports activity for the current month.
 `-w, --week` | Reports activity for the current week.
 `-d, --day` | Reports activity for the current day.
+`-a, --all` | Reports all activities.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
 `-j, --json` | Format the report in JSON instead of plain text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,11 +24,13 @@ _dt = functools.partial(datetime.datetime, tzinfo=tzutc())
     (_dt(2016, 6, 2), 'month', _dt(2016, 6, 1)),
     (_dt(2016, 6, 2), 'week', _dt(2016, 5, 30)),
     (_dt(2016, 6, 2), 'day', _dt(2016, 6, 2)),
+    (_dt(2016, 6, 2), 'all', _dt(1970, 1, 1)),
 
     (_dt(2012, 2, 24), 'year', _dt(2012, 1, 1)),
     (_dt(2012, 2, 24), 'month', _dt(2012, 2, 1)),
     (_dt(2012, 2, 24), 'week', _dt(2012, 2, 20)),
     (_dt(2012, 2, 24), 'day', _dt(2012, 2, 24)),
+    (_dt(2012, 2, 24), 'all', _dt(1970, 1, 1)),
 ])
 def test_get_start_time_for_period(now, mode, start_time):
     with mock_datetime(now, datetime):

--- a/watson.completion
+++ b/watson.completion
@@ -36,7 +36,7 @@ _watson_complete () {
               COMPREPLY=($(compgen -W "$tags" -- ${cur}))
               ;;
             *)
-              COMPREPLY=($(compgen -W "-c -C -d -f -g -G -j -m -p -t -T -w -y --current --no-current --pager --no-pager --from --to --project --tag --day --week --month --year --json" -- ${cur})) ;;
+              COMPREPLY=($(compgen -W "-a -c -C -d -f -g -G -j -m -p -t -T -w -y --all --current --no-current --pager --no-pager --from --to --project --tag --day --week --month --year --json" -- ${cur})) ;;
           esac
           ;;
         merge)

--- a/watson.zsh-completion
+++ b/watson.zsh-completion
@@ -126,6 +126,7 @@ _watson() {
             '*'{-T,--tag}'[only for the given tag]: :_watson_tags' \
             '(--from -f)'{-f,--from}'[start date]:date (YYYY-MM-DD):' \
             '(--to -t)'{-t,--to}'[end date]:date (YYYY-MM-DD):' \
+            '(--all -a)'{-a,--all}'[output all frames]:' \
             '--help'
           ;;
         (merge)

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -311,7 +311,7 @@ def status(watson, project, tags, elapsed):
     ))
 
 
-_SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
+_SHORTCUT_OPTIONS = ['all', 'year', 'month', 'week', 'day']
 
 
 @cli.command()
@@ -329,20 +329,24 @@ _SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
               "Defaults to tomorrow.")
 @click.option('-y', '--year', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('year'),
-              mutually_exclusive=['day', 'week', 'month'],
+              mutually_exclusive=['day', 'week', 'month', 'all'],
               help='Reports activity for the current year.')
 @click.option('-m', '--month', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('month'),
-              mutually_exclusive=['day', 'week', 'year'],
+              mutually_exclusive=['day', 'week', 'year', 'all'],
               help='Reports activity for the current month.')
 @click.option('-w', '--week', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('week'),
-              mutually_exclusive=['day', 'month', 'year'],
+              mutually_exclusive=['day', 'month', 'year', 'all'],
               help='Reports activity for the current week.')
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('day'),
-              mutually_exclusive=['week', 'month', 'year'],
+              mutually_exclusive=['week', 'month', 'year', 'all'],
               help='Reports activity for the current day.')
+@click.option('-a', '--all', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('all'),
+              mutually_exclusive=['day', 'week', 'month', 'year'],
+              help='Reports all activities.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Reports activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -356,7 +360,7 @@ _SHORTCUT_OPTIONS = ['year', 'month', 'week', 'day']
               help="(Don't) view output through a pager.")
 @click.pass_obj
 def report(watson, current, from_, to, projects,
-           tags, year, month, week, day, format_json, pager):
+           tags, year, month, week, day, all, format_json, pager):
     """
     Display a report of the time spent on each project.
 
@@ -424,7 +428,7 @@ def report(watson, current, from_, to, projects,
             [steering 10h 33m 37s]
             [wheels   10h 11m 35s]
     \b
-    $ watson report --format json
+    $ watson report --json
     {
         "projects": [
             {
@@ -451,7 +455,8 @@ def report(watson, current, from_, to, projects,
     """
     try:
         report = watson.report(from_, to, current, projects, tags,
-                               year=year, month=month, week=week, day=day)
+                               year=year, month=month, week=week, day=day,
+                               all=all)
     except watson.WatsonError as e:
         raise click.ClickException(e)
 
@@ -532,20 +537,24 @@ def report(watson, current, from_, to, projects,
               "Defaults to tomorrow.")
 @click.option('-y', '--year', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('year'),
-              mutually_exclusive=['day', 'week', 'month'],
+              mutually_exclusive=['day', 'week', 'month', 'all'],
               help='Reports activity for the current year.')
 @click.option('-m', '--month', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('month'),
-              mutually_exclusive=['day', 'week', 'year'],
+              mutually_exclusive=['day', 'week', 'year', 'all'],
               help='Reports activity for the current month.')
 @click.option('-w', '--week', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('week'),
-              mutually_exclusive=['day', 'month', 'year'],
+              mutually_exclusive=['day', 'month', 'year', 'all'],
               help='Reports activity for the current week.')
 @click.option('-d', '--day', cls=MutuallyExclusiveOption, type=Date,
               flag_value=get_start_time_for_period('day'),
-              mutually_exclusive=['week', 'month', 'year'],
+              mutually_exclusive=['week', 'month', 'year', 'all'],
               help='Reports activity for the current day.')
+@click.option('-a', '--all', cls=MutuallyExclusiveOption, type=Date,
+              flag_value=get_start_time_for_period('all'),
+              mutually_exclusive=['day', 'week', 'month', 'year'],
+              help='Reports all activities.')
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Logs activity only for the given project. You can add "
               "other projects by using this option several times.")
@@ -559,7 +568,7 @@ def report(watson, current, from_, to, projects,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 def log(watson, current, from_, to, projects, tags, year, month, week, day,
-        format_json, pager):
+        all, format_json, pager):
     """
     Display each recorded session during the given timespan.
 
@@ -608,7 +617,7 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
     """  # noqa
-    for start_time in (_ for _ in [day, week, month, year]
+    for start_time in (_ for _ in [day, week, month, year, all]
                        if _ is not None):
         from_ = start_time
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -144,6 +144,9 @@ def get_start_time_for_period(period):
         start_time = arrow.Arrow(year, month, 1)
     elif period == 'year':
         start_time = arrow.Arrow(year, 1, 1)
+    elif period == 'all':
+        # approximately timestamp `0`
+        start_time = arrow.Arrow(1970, 1, 1)
     else:
         raise ValueError('Unsupported period value: {}'.format(period))
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -414,8 +414,8 @@ class Watson(object):
         return conflicting, merging
 
     def report(self, from_, to, current=None, projects=None, tags=None,
-               year=None, month=None, week=None, day=None):
-        for start_time in (_ for _ in [day, week, month, year]
+               year=None, month=None, week=None, day=None, all=None):
+        for start_time in (_ for _ in [day, week, month, year, all]
                            if _ is not None):
             from_ = start_time
 


### PR DESCRIPTION
`--year` was a brilliant way to get "everything", but we're in a new year now...

`-a / --all` is set to use a start date of Jan 1, 1970 (close to timestamp `0`). Alternately, I guess we could try and figure out when the first frame starts, but this seemed like it would be faster at runtime and less likely to break.
  