### PR TITLE
Update path to frame file on Darwin OS.

### DIFF
--- a/watson.zsh-completion
+++ b/watson.zsh-completion
@@ -27,7 +27,7 @@ _watson_commands=(
 if [[ -n "$WATSON_DIR" ]]; then
   _watson_frame_file=${WATSON_DIR}/frames
 elif [[ "$OSTYPE" =~ "^darwin" ]]; then
-  _watson_frame_file=${HOME}/Library/Application Support/frames
+  _watson_frame_file="${HOME}/Library/Application Support/watson/frames"
 else
   _watson_frame_file=${HOME}/.config/watson/frames
 fi


### PR DESCRIPTION
After a fresh Watson installation on "El Captain", I got this error when using ZSH completion.

```bash
_watson:30: no such file or directory: Support/frames
```

I checked in the installation folder and found that the path to the frames file is invalid. It contains a space so it must be surrounded by quotes and it miss the `watson` folder.

After applying that changes, completion works like a charm 😋.