### PR TITLE
[WIP] add option to add aliases to commands

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -275,7 +275,7 @@ Flag | Help
 ## `remove`
 
 ```bash
-Usage:  watson remove [OPTIONS] ID
+Usage:  watson remove [OPTIONS]
 ```
 
 Remove a frame. You can specify the frame either by id or by position
@@ -285,7 +285,6 @@ Remove a frame. You can specify the frame either by id or by position
 
 Flag | Help
 -----|-----
-`-f, --force` | Don't ask for confirmation.
 `--help` | Show this message and exit.
 
 ## `rename`


### PR DESCRIPTION
I am trying to make it possible to add aliases to commands, so you can type e.g. `watson remove` or `watson delete`.

This works, however it breaks the documentation by deleting the output for:
```
 @click.argument('id')
 @click.option('-f', '--force', is_flag=True,
               help="Don't ask for confirmation.")
```

If I move these two options below `cli.command` it works. I'm not sure why.

Also the `help` is broken for `watson remove` (but not `watson delete`):

```
basti$ watson help delete
Usage: watson help [OPTIONS] ID

  Remove a frame. You can specify the frame either by id or by position (ex:
  `-1` for the last frame).

Options:
  -f, --force  Don't ask for confirmation.
  --help       Show this message and exit.
(watson) [~/git/Watson] (alias_for_commands)
```
See the missing `ID` and `-f` options:
```
basti$ watson help remove
Usage: watson help [OPTIONS]

  Remove a frame. You can specify the frame either by id or by position (ex:
  `-1` for the last frame).

Options:
  --help  Show this message and exit.
```

I guess the reason for these problems are the same, however I don't know how to fix this.

What do you think of this PR?