### PR TITLE
Allow arrow v0.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-arrow!=0.11,!=0.12
+arrow!=0.11,!=0.12.0
 click
 requests


### PR DESCRIPTION
arrow versions 0.11.0 and 0.12.0 are both broken, but 0.12.1 works. This builds off of #175 and #180.