### PR TITLE
PR: Fix empty current not saved correctly when not using Watson in the CLI

### DIFF
--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -358,14 +358,21 @@ def test_save_current_without_tags(mock, watson, json_mock):
 
 
 def test_save_empty_current(config_dir, mock, json_mock):
-    watson = Watson(current={'project': 'foo', 'start': 4000},
-                    config_dir=config_dir)
-    watson.current = {}
+    watson = Watson(current={}, config_dir=config_dir)
 
     mock.patch('%s.open' % builtins, mock.mock_open())
+
+    watson.current = {'project': 'foo', 'start': 4000}
     watson.save()
 
     assert json_mock.call_count == 1
+    result = json_mock.call_args[0][0]
+    assert result == {'project': 'foo', 'start': 4000, 'tags': []}
+
+    watson.current = {}
+    watson.save()
+
+    assert json_mock.call_count == 2
     result = json_mock.call_args[0][0]
     assert result == {}
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -152,6 +152,7 @@ class Watson(object):
                     current = {}
 
                 safe_save(self.state_file, make_json_writer(lambda: current))
+                self._old_state = current
 
             if self._frames is not None and self._frames.changed:
                 safe_save(self.frames_file,


### PR DESCRIPTION
Fixes #213

- [x] Modify `test_save_empty_current` to catch the bug described in #213 
- [x] Set `Watson._old_state` to `current` after each save of `current` in `Watson.save`