### PR TITLE
 start,add and edit can confirm new project or tag 

### DIFF
--- a/watson/utils.py
+++ b/watson/utils.py
@@ -29,8 +29,7 @@ def confirm_project(watson, project, confirm_new_project):
                                 'confirm_new_project') or confirm_new_project:
         if project not in watson.projects:
             msg = "Project '%s' does not exist yet. Create it?" % project
-            if not click.confirm(msg,
-                err=True):
+            if not click.confirm(msg, err=True):
                 click.echo("Aborting operation.", err=True)
                 sys.exit(1)
 
@@ -41,8 +40,7 @@ def confirm_tags(watson, tags, confirm_new_tag):
         for tag in tags:
             if tag not in watson.tags:
                 msg = "Tag '%s' does not exist yet. Create it?" % tag
-                if not click.confirm(msg,
-                    err=True):
+                if not click.confirm(msg, err=True):
                     click.echo("Aborting operation.", err=True)
                     sys.exit(1)
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -33,6 +33,7 @@ def confirm_project(watson, project, confirm_new_project):
                 click.echo("Aborting operation.", err=True)
                 sys.exit(1)
 
+
 def confirm_tags(watson, tags, confirm_new_tag):
     # https://github.com/TailorDev/Watson/issues/191 - for tags
     if watson.config.getboolean('options',
@@ -43,6 +44,7 @@ def confirm_tags(watson, tags, confirm_new_tag):
                 if not click.confirm(msg, err=True):
                     click.echo("Aborting operation.", err=True)
                     sys.exit(1)
+
 
 def style(name, element):
     def _style_tags(tags):

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -23,6 +23,29 @@ except NameError:
     text_type = str
 
 
+def confirm_project(watson, project, confirm_new_project):
+    # https://github.com/TailorDev/Watson/issues/191 - for project
+    if watson.config.getboolean('options',
+                                'confirm_new_project') or confirm_new_project:
+        if project not in watson.projects:
+            msg = "Project '%s' does not exist yet. Create it?" % project
+            if not click.confirm(msg,
+                err=True):
+                click.echo("Aborting operation.", err=True)
+                sys.exit(1)
+
+def confirm_tags(watson, tags, confirm_new_tag):
+    # https://github.com/TailorDev/Watson/issues/191 - for tags
+    if watson.config.getboolean('options',
+                                'confirm_new_tag') or confirm_new_tag:
+        for tag in tags:
+            if tag not in watson.tags:
+                msg = "Tag '%s' does not exist yet. Create it?" % tag
+                if not click.confirm(msg,
+                    err=True):
+                    click.echo("Aborting operation.", err=True)
+                    sys.exit(1)
+
 def style(name, element):
     def _style_tags(tags):
         if not tags:


### PR DESCRIPTION
In issue https://github.com/TailorDev/Watson/issues/191 possibility to configure Watson to warn about adding projects and/or tags that do not exist yet was requested.

This pull requests now implements this feature. By adding --confirm-new-project or --confirm-new-tag to start, add or edit commands this feature is enabled. By default --no-confirm-new-project and --no-confirm-new-tag are in effect. This feature can also be enabled by adding confirm_new_project = true and/or confirm_new_tag = true to Watson configuration file under 'options' section.