### PR TITLE
Negate option for projects and tags options in log/report commands

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -179,7 +179,9 @@ Flag | Help
 `-d, --day` | Reports activity for the current day.
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
+`-P, --exclude-projects` | Exclude projects given by --project option.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-e, --exclude-tags` | Exclude tags given by --tag option
 `-j, --json` | Format the log in JSON instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
@@ -426,7 +428,9 @@ Flag | Help
 `-d, --day` | Reports activity for the current day.
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
+`-P, --exclude-projects` | Exclude projects given by --project option.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-e, --exclude-tags` | Exclude tags given by --tag option
 `-j, --json` | Format the report in JSON instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -194,6 +194,7 @@ def test_frames_with_empty_given_state(config_dir, mock):
     mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
     assert len(watson.frames) == 0
 
+
 def test_frames_filter(watson):
     samples = (
         ('foo', ('A')),
@@ -212,7 +213,8 @@ def test_frames_filter(watson):
         len += 1
     assert len == 2
 
-    not_foo_projects = watson.frames.filter(projects=('foo'), exclude_projects=True)
+    not_foo_projects = watson.frames.filter(projects=('foo'),
+                                            exclude_projects=True)
     len = 0
     for frame in not_foo_projects:
         assert frame.project != 'foo'
@@ -233,7 +235,8 @@ def test_frames_filter(watson):
         len += 1
     assert len == 2
 
-    foo_not_A = watson.frames.filter(projects=('foo'), tags=('A'), exclude_tags=True)
+    foo_not_A = watson.frames.filter(projects=('foo'), tags=('A'),
+                                     exclude_tags=True)
     len = 0
     for frame in foo_not_A:
         assert frame.tags != 'A'
@@ -241,7 +244,8 @@ def test_frames_filter(watson):
         len += 1
     assert len == 1
 
-    not_foo_A = watson.frames.filter(projects=('foo'), tags=('A'), exclude_projects=True)
+    not_foo_A = watson.frames.filter(projects=('foo'), tags=('A'),
+                                     exclude_projects=True)
     len = 0
     for frame in not_foo_A:
         assert frame.tags == 'A'
@@ -249,7 +253,9 @@ def test_frames_filter(watson):
         len += 1
     assert len == 2
 
-    not_foo_not_A = watson.frames.filter(projects=('foo'), tags=('A'), exclude_projects=True, exclude_tags=True)
+    not_foo_not_A = watson.frames.filter(projects=('foo'), tags=('A'),
+                                         exclude_projects=True,
+                                         exclude_tags=True)
     len = 0
     for frame in not_foo_not_A:
         assert frame.tags != 'A'

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -194,6 +194,69 @@ def test_frames_with_empty_given_state(config_dir, mock):
     mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
     assert len(watson.frames) == 0
 
+def test_frames_filter(watson):
+    samples = (
+        ('foo', ('A')),
+        ('bar', ('A')),
+        ('foo', ('B')),
+        ('lol', ('B')),
+        ('bar', ('A'))
+    )
+    for name, tags in samples:
+        watson.frames.add(name, 4000, 4000, tags)
+
+    foo_projects = watson.frames.filter(projects=('foo'))
+    len = 0
+    for frame in foo_projects:
+        assert frame.project == 'foo'
+        len += 1
+    assert len == 2
+
+    not_foo_projects = watson.frames.filter(projects=('foo'), exclude_projects=True)
+    len = 0
+    for frame in not_foo_projects:
+        assert frame.project != 'foo'
+        len += 1
+    assert len == 3
+
+    A_tags = watson.frames.filter(tags=('A'))
+    len = 0
+    for frame in A_tags:
+        assert frame.tags == 'A'
+        len += 1
+    assert len == 3
+
+    not_A_tags = watson.frames.filter(tags=('A'), exclude_tags=True)
+    len = 0
+    for frame in not_A_tags:
+        assert frame.tags != 'A'
+        len += 1
+    assert len == 2
+
+    foo_not_A = watson.frames.filter(projects=('foo'), tags=('A'), exclude_tags=True)
+    len = 0
+    for frame in foo_not_A:
+        assert frame.tags != 'A'
+        assert frame.project == 'foo'
+        len += 1
+    assert len == 1
+
+    not_foo_A = watson.frames.filter(projects=('foo'), tags=('A'), exclude_projects=True)
+    len = 0
+    for frame in not_foo_A:
+        assert frame.tags == 'A'
+        assert frame.project != 'foo'
+        len += 1
+    assert len == 2
+
+    not_foo_not_A = watson.frames.filter(projects=('foo'), tags=('A'), exclude_projects=True, exclude_tags=True)
+    len = 0
+    for frame in not_foo_not_A:
+        assert frame.tags != 'A'
+        assert frame.project != 'foo'
+        len += 1
+    assert len == 1
+
 
 # config
 

--- a/watson.completion
+++ b/watson.completion
@@ -58,7 +58,7 @@ _watson_complete () {
               COMPREPLY=($(compgen -W "$tags" -- ${cur}))
               ;;
             *)
-              COMPREPLY=($(compgen -W "-a -c -C -d -f -g -G -j -m -p -t -T -w -y --all --current --no-current --pager --no-pager --from --to --project --tag --day --week --month --year --luna --json" -- ${cur})) ;;
+              COMPREPLY=($(compgen -W "-a -c -C -d -f -g -G -j -m -p -P -t -e -T -w -y --all --current --no-current --pager --no-pager --from --to --project --tag --day --week --month --year --luna --json --exclude-projects --exclude-tags" -- ${cur})) ;;
           esac
           ;;
         merge)

--- a/watson.zsh-completion
+++ b/watson.zsh-completion
@@ -134,7 +134,9 @@ _watson() {
         (log|report)
           _arguments : \
             '*'{-p,--project}'[only for the given project]: :_watson_projects' \
+            '(-P --exclude-projects)'{--exclude-projects -P}'[exclude projects]:' \
             '*'{-T,--tag}'[only for the given tag]: :_watson_tags' \
+            '(-e --exclude-tags)'{--exclude-tags -e}'[exclude tags]:' \
             '(--from -f)'{-f,--from}'[start date]:date (YYYY-MM-DD):' \
             '(--to -t)'{-t,--to}'[end date]:date (YYYY-MM-DD):' \
             '(--all -a)'{-a,--all}'[output all frames]:' \

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -349,17 +349,21 @@ _SHORTCUT_OPTIONS_VALUES = {
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Reports activity only for the given project. You can add "
               "other projects by using this option several times.")
+@click.option('-P', '--exclude-projects', 'exclude_projects', is_flag=True,
+              help="Exclude projects given by --project option.")
 @click.option('-T', '--tag', 'tags', multiple=True,
               help="Reports activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
+@click.option('-e', '--exclude-tags', 'exclude_tags', is_flag=True,
+              help="Exclude tags given by --tag option")
 @click.option('-j', '--json', 'format_json', is_flag=True,
               help="Format the report in JSON instead of plain text")
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 def report(watson, current, from_, to, projects, tags, year, month,
-           week, day, luna, all, format_json, pager):
+           week, day, luna, all, format_json, pager, exclude_projects, exclude_tags):
     """
     Display a report of the time spent on each project.
 
@@ -457,7 +461,8 @@ def report(watson, current, from_, to, projects, tags, year, month,
     try:
         report = watson.report(from_, to, current, projects, tags,
                                year=year, month=month, week=week, day=day,
-                               luna=luna, all=all)
+                               luna=luna, all=all, exclude_projects=exclude_projects,
+                               exclude_tags=exclude_tags)
     except watson.WatsonError as e:
         raise click.ClickException(e)
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -563,17 +563,21 @@ def report(watson, current, from_, to, projects, tags, year, month,
 @click.option('-p', '--project', 'projects', multiple=True,
               help="Logs activity only for the given project. You can add "
               "other projects by using this option several times.")
+@click.option('-P', '--exclude-projects', 'exclude_projects', is_flag=True,
+              help="Exclude projects given by --project option.")
 @click.option('-T', '--tag', 'tags', multiple=True,
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
+@click.option('-e', '--exclude-tags', 'exclude_tags', is_flag=True,
+              help="Exclude tags given by --tag option")
 @click.option('-j', '--json', 'format_json', is_flag=True,
               help="Format the log in JSON instead of plain text")
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 def log(watson, current, from_, to, projects, tags, year, month, week, day,
-        luna, all, format_json, pager):
+        luna, all, format_json, pager, exclude_projects, exclude_tags):
     """
     Display each recorded session during the given timespan.
 
@@ -640,7 +644,8 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
 
     span = watson.frames.span(from_, to)
     filtered_frames = watson.frames.filter(
-        projects=projects or None, tags=tags or None, span=span
+        projects=projects or None, tags=tags or None, span=span,
+        exclude_projects=exclude_projects or False, exclude_tags=exclude_tags or False
     )
 
     if format_json:

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -362,8 +362,8 @@ _SHORTCUT_OPTIONS_VALUES = {
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
 @click.pass_obj
-def report(watson, current, from_, to, projects, tags, year, month,
-           week, day, luna, all, format_json, pager, exclude_projects, exclude_tags):
+def report(watson, current, from_, to, projects, tags, year, month, week, day,
+           luna, all, format_json, pager, exclude_projects, exclude_tags):
     """
     Display a report of the time spent on each project.
 
@@ -461,7 +461,8 @@ def report(watson, current, from_, to, projects, tags, year, month,
     try:
         report = watson.report(from_, to, current, projects, tags,
                                year=year, month=month, week=week, day=day,
-                               luna=luna, all=all, exclude_projects=exclude_projects,
+                               luna=luna, all=all,
+                               exclude_projects=exclude_projects,
                                exclude_tags=exclude_tags)
     except watson.WatsonError as e:
         raise click.ClickException(e)
@@ -650,7 +651,8 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
     span = watson.frames.span(from_, to)
     filtered_frames = watson.frames.filter(
         projects=projects or None, tags=tags or None, span=span,
-        exclude_projects=exclude_projects or False, exclude_tags=exclude_tags or False
+        exclude_projects=exclude_projects or False,
+        exclude_tags=exclude_tags or False
     )
 
     if format_json:

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -143,11 +143,14 @@ class Frames(object):
     def dump(self):
         return tuple(frame.dump() for frame in self._rows)
 
-    def filter(self, projects=None, tags=None, span=None, exclude_projects=False, exclude_tags=False):
+    def filter(self, projects=None, tags=None, span=None,
+               exclude_projects=False, exclude_tags=False):
         return (
             frame for frame in self._rows
-            if (projects is None or ((frame.project in projects) != exclude_projects)) and
-               (tags is None or (any(tag in frame.tags for tag in tags) != exclude_tags)) and
+            if (projects is None or
+                ((frame.project in projects) != exclude_projects)) and
+               (tags is None or
+                (any(tag in frame.tags for tag in tags) != exclude_tags)) and
                (span is None or frame in span)
         )
 

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -143,11 +143,11 @@ class Frames(object):
     def dump(self):
         return tuple(frame.dump() for frame in self._rows)
 
-    def filter(self, projects=None, tags=None, span=None, exclude_projects=False):
+    def filter(self, projects=None, tags=None, span=None, exclude_projects=False, exclude_tags=False):
         return (
             frame for frame in self._rows
             if (projects is None or ((frame.project in projects) != exclude_projects)) and
-               (tags is None or any(tag in frame.tags for tag in tags)) and
+               (tags is None or (any(tag in frame.tags for tag in tags) != exclude_tags)) and
                (span is None or frame in span)
         )
 

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -143,10 +143,10 @@ class Frames(object):
     def dump(self):
         return tuple(frame.dump() for frame in self._rows)
 
-    def filter(self, projects=None, tags=None, span=None):
+    def filter(self, projects=None, tags=None, span=None, exclude_projects=False):
         return (
             frame for frame in self._rows
-            if (projects is None or frame.project in projects) and
+            if (projects is None or ((frame.project in projects) != exclude_projects)) and
                (tags is None or any(tag in frame.tags for tag in tags)) and
                (span is None or frame in span)
         )

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -428,7 +428,7 @@ class Watson(object):
 
     def report(self, from_, to, current=None, projects=None, tags=None,
                year=None, month=None, week=None, day=None, luna=None,
-               all=None):
+               all=None, exclude_projects=False, exclude_tags=False):
         for start_time in (_ for _ in [day, week, month, year, luna, all]
                            if _ is not None):
             from_ = start_time
@@ -451,7 +451,8 @@ class Watson(object):
 
         frames_by_project = sorted_groupby(
             self.frames.filter(
-                projects=projects or None, tags=tags or None, span=span
+                projects=projects or None, tags=tags or None, span=span,
+                exclude_projects=exclude_projects, exclude_tags=exclude_tags
             ),
             operator.attrgetter('project')
         )
@@ -483,7 +484,7 @@ class Watson(object):
 
             tags_to_print = sorted(
                 set(tag for frame in frames for tag in frame.tags
-                    if tag in tags or not tags)
+                    if ((tag in tags) != exclude_tags) or not tags)
             )
 
             for tag in tags_to_print:


### PR DESCRIPTION
Hi,

One use case I usually need in a log or a report is to show all projects but one or two, or frames with all tags but one.

So here is --exclude-tags and --exclude-projects flag option that exclude given tags or projects by --tag or --project options in log and report command.

In order to be able to type:  
`watson log -Gd -p coding -T personal --exclude-tags`  
to have log of code activity of the day, but not the personal ones.