### PR TITLE
Provide support to  add multiple passed time trackings

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -642,7 +642,7 @@ Example:
 
 
     $ watson stop --at 13:37
-    Stopping project apollo11, started a minute ago, at 30 minutes ago. (id: e9ccd52) # noqa: E501
+    Stopping project apollo11, started a minute ago, at 30 minutes ago. (id: e9ccd52)
 
 ### Options
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -577,16 +577,20 @@ If there is already a running project and the configuration option
 `options.stop_on_start` is set to a true value (`1`, `on`, `true` or
 `yes`), it is stopped before the new project is started.
 
+If the '--no-gap' flag is given, the start time of the new project is set
+to the stop time of the most recently stopped project.
+
 Example:
 
 
-    $ watson start apollo11 +module +brakes
+    $ watson start apollo11 +module +brakes --no-gap
     Starting project apollo11 [module, brakes] at 16:34
 
 ### Options
 
 Flag | Help
 -----|-----
+`-g, --gap / -G, --no-gap` | (Don't) leave gap between end time of previous project and start time of the current.
 `--help` | Show this message and exit.
 
 ## `status`
@@ -630,16 +634,21 @@ Usage:  watson stop [OPTIONS]
 
 Stop monitoring time for the current project.
 
+If '--at' option is given, the provided stopping time is used. The
+specified time must be after the begin of the to be ended frame and must
+not be in the future.
+
 Example:
 
 
-    $ watson stop
-    Stopping project apollo11, started a minute ago. (id: e7ccd52)
+    $ watson stop --at 13:37
+    Stopping project apollo11, started a minute ago, at 30 minutes ago. (id: e9ccd52) # noqa: E501
 
 ### Options
 
 Flag | Help
 -----|-----
+`--at TIME` | Stop frame at this time. Must be in (YYYY-MM-DDT)?HH:MM(:SS)? format.
 `--help` | Show this message and exit.
 
 ## `sync`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -642,7 +642,7 @@ Example:
 
 
     $ watson stop --at 13:37
-    Stopping project apollo11, started a minute ago, at 30 minutes ago. (id: e9ccd52)
+    Stopping project apollo11, started an hour ago and stopped 30 minutes ago. (id: e9ccd52)
 
 ### Options
 

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -271,11 +271,11 @@ my project = A B
     assert watson.current['tags'] == ['C', 'D', 'A', 'B']
 
 
-def test_start_seamless(mock, watson):
+def test_start_nogap(mock, watson):
 
     watson.start('foo')
     watson.stop()
-    watson.start('bar', seamless=True)
+    watson.start('bar', gap=False)
 
     assert watson.frames[-1].stop == watson.current['start']
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -76,8 +76,8 @@ class TimeParamType(click.ParamType):
         if isinstance(value, arrow.Arrow):
             return value
 
-        date_pattern = '\d{4}-\d\d-\d\d'  # noqa: W605
-        time_pattern = '\d\d:\d\d(:\d\d)?'  # noqa: W605
+        date_pattern = r'\d{4}-\d\d-\d\d'
+        time_pattern = r'\d\d:\d\d(:\d\d)?'
 
         if re.match('^{time_pat}$'.format(time_pat=time_pattern), value):
             cur_date = arrow.now().date().isoformat()

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -179,7 +179,7 @@ def start(ctx, watson, args, seamless_=False):
 
 
 @cli.command(context_settings={'ignore_unknown_options': True})
-@click.option('--at', 'at_', type=Time, default=arrow.now(),
+@click.option('--at', 'at_', type=Time, default=None,
               help='Stop frame at this time. Must be in HH:MM(:SS)? format.')
 @click.pass_obj
 def stop(watson, at_):

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -181,9 +181,10 @@ def start(ctx, watson, args, gap_=True):
     tags = parse_tags(args)
 
     if project and watson.is_started and not gap_:
-        errmsg = ''.join(("Project {} is already started and '--no-gap' is ",
-                          "passed. Please stop manually."))
-        raise _watson.WatsonError(errmsg.format(project))
+        current = watson.current
+        errmsg = ("Project {} is already started and '--no-gap' is passed. "
+                  "Please stop manually.")
+        raise _watson.WatsonError(errmsg.format(current['project']))
 
     if (project and watson.is_started and
             watson.config.getboolean('options', 'stop_on_start')):

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -149,7 +149,8 @@ def _start(watson, project, tags, restart=False, gap=True):
 
 @cli.command()
 @click.option('-g/-G', '--gap/--no-gap', 'gap_', is_flag=True, default=True,
-              help="Set start time to stop time of previous project")
+              help=("(Don't) leave gap between end time of previous project "
+                    "and start time of the current."))
 @click.argument('args', nargs=-1)
 @click.pass_obj
 @click.pass_context

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -134,11 +134,11 @@ def help(ctx, command):
     click.echo(cmd.get_help(ctx))
 
 
-def _start(watson, project, tags, restart=False, seamless=False):
+def _start(watson, project, tags, restart=False, gap=True):
     """
     Start project with given list of tags and save status.
     """
-    current = watson.start(project, tags, restart=restart, seamless=seamless)
+    current = watson.start(project, tags, restart=restart, gap=gap)
     click.echo(u"Starting project {}{} at {}".format(
         style('project', project),
         (" " if current['tags'] else "") + style('tags', current['tags']),
@@ -148,12 +148,12 @@ def _start(watson, project, tags, restart=False, seamless=False):
 
 
 @cli.command()
-@click.option('-s', '--seamless', 'seamless_', is_flag=True, default=False,
+@click.option('-g/-G', '--gap/--no-gap', 'gap_', is_flag=True, default=True,
               help="Set start time to stop time of previous project")
 @click.argument('args', nargs=-1)
 @click.pass_obj
 @click.pass_context
-def start(ctx, watson, args, seamless_=False):
+def start(ctx, watson, args, gap_=True):
     """
     Start monitoring time for the given project.
     You can add tags indicating more specifically what you are working on with
@@ -163,13 +163,13 @@ def start(ctx, watson, args, seamless_=False):
     `options.stop_on_start` is set to a true value (`1`, `on`, `true` or
     `yes`), it is stopped before the new project is started.
 
-    If the '--seamless' flag is given, the start time of the new project is set
+    If the '--no-gap' flag is given, the start time of the new project is set
     to the stop time of the most recently stopped project.
 
     Example:
 
     \b
-    $ watson start apollo11 +module +brakes --seamless
+    $ watson start apollo11 +module +brakes --no-gap
     Starting project apollo11 [module, brakes] at 16:34
     """
     project = ' '.join(
@@ -179,8 +179,8 @@ def start(ctx, watson, args, seamless_=False):
     # Parse all the tags
     tags = parse_tags(args)
 
-    if project and watson.is_started and seamless_:
-        errmsg = ''.join(("Project {} is already started and '--seamless' is ",
+    if project and watson.is_started and not gap_:
+        errmsg = ''.join(("Project {} is already started and '--no-gap' is ",
                           "passed. Please stop manually."))
         raise _watson.WatsonError(errmsg.format(project))
 
@@ -188,7 +188,7 @@ def start(ctx, watson, args, seamless_=False):
             watson.config.getboolean('options', 'stop_on_start')):
         ctx.invoke(stop)
 
-    _start(watson, project, tags, seamless=seamless_)
+    _start(watson, project, tags, gap=gap_)
 
 
 @cli.command(context_settings={'ignore_unknown_options': True})

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -210,10 +210,11 @@ def stop(watson, at_):
 
     \b
     $ watson stop --at 13:37
-    Stopping project apollo11, started a minute ago, at 30 minutes ago. (id: e9ccd52) # noqa: E501
+    Stopping project apollo11, started an hour ago and stopped 30 minutes ago. (id: e9ccd52) # noqa: E501
     """
     frame = watson.stop(stop_at=at_)
-    click.echo(u"Stopping project {}{}, started {}, at {}. (id: {})".format(
+    output_str = u"Stopping project {}{}, started {} and stopped {}. (id: {})"
+    click.echo(output_str.format(
         style('project', frame.project),
         (" " if frame.tags else "") + style('tags', frame.tags),
         style('time', frame.start.humanize()),

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -179,6 +179,11 @@ def start(ctx, watson, args, seamless_=False):
     # Parse all the tags
     tags = parse_tags(args)
 
+    if project and watson.is_started and seamless_:
+        errmsg = ''.join(("Project {} is already started and '--seamless' is ",
+                          "passed. Please stop manually."))
+        raise _watson.WatsonError(errmsg.format(project))
+
     if (project and watson.is_started and
             watson.config.getboolean('options', 'stop_on_start')):
         ctx.invoke(stop)

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -250,7 +250,7 @@ class Watson(object):
         frame = self.frames.add(project, from_date, to_date, tags=tags)
         return frame
 
-    def start(self, project, tags=None, restart=False, seamless=False):
+    def start(self, project, tags=None, restart=False, gap=True):
         if not project:
             raise WatsonError("No project given.")
 
@@ -266,7 +266,7 @@ class Watson(object):
             tags = (tags or []) + default_tags
 
         new_frame = {'project': project, 'tags': deduplicate(tags)}
-        if seamless:
+        if not gap:
             stop_of_prev_frame = self.frames[-1].stop
             new_frame['start'] = stop_of_prev_frame
         self.current = new_frame


### PR DESCRIPTION
Merging this PR will add the functionality needed to support the workflow described in 
https://github.com/TailorDev/Watson/issues/233 and https://github.com/TailorDev/Watson/issues/234.

There are some caveats I want to mention. Please give me a hint how to resolve them or feel free to alter my commits.

  * For '--seamless', I use the last frame instead of the most recently stopped. This might cause problems after using `watson edit`. I wanted to avoid looping through the list of frames for efficiency reasons.
  * Using '-s' as short option for '--seamless' will block adding the '--stop/--no-stop' option from `watson restart` to `watson start` too.
  * The '--at' option uses the current wall clock day to complete the given time to a parseable time stamp string. This might cause issues around midnight or for very long lasting sessions.

Please let me know if should improve or add something.