### PR TITLE
Add option to specify start of the week

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -149,6 +149,13 @@ Globally configure how `dates` should be formatted. All [python's `strftime` dir
 
 Globally configure how `time` should be formatted. All [python's `strftime` directives](http://strftime.org) are supported.
 
+#### `options.week_start`
+
+Globally configure which day corresponds to the start of a week. Allowable
+values are `monday` (default), `tuesday`, `wednesday`, `thursday`, `friday`,
+ `saturday`, and `sunday`.
+
+
 ### Default tags
 
 Tags can be automatically added for selected projects. This is convenient when
@@ -211,6 +218,7 @@ stop_on_start = true
 stop_on_restart = false
 date_format = %Y.%m.%d
 time_format = %H:%M:%S%z
+week_start = monday
 log_current = false
 pager = true
 report_current = false

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -14,9 +14,9 @@ import click
 
 from . import watson as _watson
 from .frames import Frame
-from .utils import (format_timedelta, get_frame_from_argument,
-                    get_start_time_for_period, options, safe_save,
-                    sorted_groupby, style, parse_tags)
+from .utils import (apply_weekday_offset, format_timedelta,
+                    get_frame_from_argument, get_start_time_for_period,
+                    options, safe_save, sorted_groupby, style, parse_tags)
 
 
 class MutuallyExclusiveOption(click.Option):
@@ -57,6 +57,13 @@ class DateParamType(click.ParamType):
             # expected by the user, so that midnight is midnight in the local
             # timezone, not in UTC. Cf issue #16.
             date.tzinfo = tz.tzlocal()
+
+            # Add an offset to match the week beginning specified in the
+            # configuration
+            if param.name == "week":
+                week_start = ctx.obj.config.get("options", "week_start")
+                date = apply_weekday_offset(
+                    start_time=date, week_start=week_start)
             return date
 
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -61,7 +61,8 @@ class DateParamType(click.ParamType):
             # Add an offset to match the week beginning specified in the
             # configuration
             if param.name == "week":
-                week_start = ctx.obj.config.get("options", "week_start")
+                week_start = ctx.obj.config.get(
+                    "options", "week_start", "monday")
                 date = apply_weekday_offset(
                     start_time=date, week_start=week_start)
             return date

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -161,6 +161,23 @@ def get_start_time_for_period(period):
     return start_time
 
 
+def apply_weekday_offset(start_time, week_start):
+    """
+    Apply the offset required to move the start date `start_time` of a week
+    starting on Monday to that of a week starting on `week_start`.
+    """
+    weekdays = dict(zip(
+        ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday",
+         "sunday"], range(0, 7)))
+
+    new_start = week_start.lower()
+    if new_start not in weekdays:
+        return start_time
+    now = datetime.datetime.now()
+    offset = weekdays[new_start] - 7 * (weekdays[new_start] > now.weekday())
+    return start_time.replace(days=offset)
+
+
 def make_json_writer(func, *args, **kwargs):
     """
     Return a function that receives a file-like object and writes the return


### PR DESCRIPTION
This PR adds a configurable option, `options.week_start`, that allows specifying the start day of a week for reporting and logging purposes. 

This is useful for those who (like me) need to report weekly time based on a starting day other than Monday. Sunday would be the other common starting day, but I've added the option to specify any day of the week, for completeness. 

I've included tests, and a short entry in the docs.

Open to suggestions, of course!