### PR TITLE
Add some information in the documentation for beginners.

### DIFF
--- a/docs/contributing/hack.md
+++ b/docs/contributing/hack.md
@@ -15,13 +15,52 @@ Ready to contribute? Here's how to set up *Watson* for local development.
         $ cd Watson
         $ pip install -r requirements-dev.txt
         $ python setup.py develop
+    
+    A few notes:
+
+      - Beware that, depending on your configuration, your virtual environment
+        may be created in a centralized location (like `$HOME/.virtualenvs`),
+        and not in the current folder.
+      
+      - Also, beware that changing the names of the folders pointing to this
+        development folder may give an undesired behavior.
+      
+      - It is probably a good idea to copy (at least) some of your existing
+        watson frames into your new development folder, to test your changes:
+      
+            $ cp -R ~/.config/watson ./data/
+      
+        To make these used by watson, it is necessary to set the `WATSON_DIR`
+        variable. It can be set with:
+      
+            $ export WATSON_DIR=$PWD/data
+      
+        It may be a good idea to modify the `bin/activate` file from your virtualenv
+        (either `venv/bin/activate` or `$HOME/.virtualenvs/watson/bin/activate`),
+        and add the following lines (just before the `PATH` settings, for instance):
+        
+            WATSON_DIR=$PWD/data
+            export WATSON_DIR
+        
+        This will be set each time you start the virtualenv and you will not have to
+        re-set the variable each time.
 
 4.  Create a branch for local development:
 
         $ git checkout -b name-of-your-bugfix-or-feature
 
     Now you can make your changes locally.
-
+    
+    The files you need to edit to change watson's behavior are located in the
+    `watson/` subfolder. 
+    
+    To test, you can add a word or two in the sentences output by the `watson
+    status` command (for instance, modify the "No project started" string in
+    `watson/cli.py`). Save your modifications, type `watson status`. If you can
+    see the words you added, you are ready to hack (congratulations!). You may
+    revert to the original version of `watson/cli.py` with `git checkout
+    watson/cli.py`.
+    
 5.  When you're done making changes, check that your changes pass the tests
     (see [Run the tests](#run-the-tests)):
 
@@ -30,6 +69,12 @@ Ready to contribute? Here's how to set up *Watson* for local development.
 6. If you have added a new command or updated/fixed docstrings, please update the documentation:
 
         $ make docs
+   
+     Beware that mkdocs 0.14 is not compatible with Python 3.7: you should either
+     use a virtualenv with Python 3.6 or update `mkdocs` to a more recent version
+     (1.0.4 at the time of writing, which also requires running `pip install
+     --upgrade mkdocs-bootstrap mkdocs-bootswatch` to get the `flatly` theme
+     used by our docs). 
 
 7.  Commit your changes and push your branch to GitHub:
 


### PR DESCRIPTION
Questions raised from the previous version and answered by the new paragraphs:
- Which files should one edit after setting up the environment?
- How to copy some real frames from a working watson install towards the
development one?
- How to set up the environment variable WATSON_DIR?
- How to avoid the incompatibility between mkdocs 0.14 and Python 3.7?

Most information was given by @jmaupetit in https://github.com/TailorDev/Watson/issues/238.

Fix #238 