### PR TITLE
Make sure bad dates in add command give nice cli errors instead of tr…

### DIFF
--- a/watson/cli.py
+++ b/watson/cli.py
@@ -53,7 +53,10 @@ class DateParamType(click.ParamType):
 
     def convert(self, value, param, ctx):
         if value:
-            date = arrow.get(value)
+            try:
+                date = arrow.get(value)
+            except arrow.parser.ParserError as e:
+                raise click.UsageError(str(e))
             # When we parse a date, we want to parse it in the timezone
             # expected by the user, so that midnight is midnight in the local
             # timezone, not in UTC. Cf issue #16.


### PR DESCRIPTION
…aceback from arrow. Fixes #247.

I was a little in doubt about what to actually give as the error message. The arrow exception didn't contain the failed formats which could be used to format a message for our selves, other than in the string. The arrow message string is nice enough, but it does of course mean we don't have control over it. If you think this is a problem I will fix it.