### PR TITLE
Add `start --no-gap` and `stop --at`

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -577,16 +577,20 @@ If there is already a running project and the configuration option
 `options.stop_on_start` is set to a true value (`1`, `on`, `true` or
 `yes`), it is stopped before the new project is started.
 
+If the '--no-gap' flag is given, the start time of the new project is set
+to the stop time of the most recently stopped project.
+
 Example:
 
 
-    $ watson start apollo11 +module +brakes
+    $ watson start apollo11 +module +brakes --no-gap
     Starting project apollo11 [module, brakes] at 16:34
 
 ### Options
 
 Flag | Help
 -----|-----
+`-g, --gap / -G, --no-gap` | (Don't) leave gap between end time of previous project and start time of the current.
 `--help` | Show this message and exit.
 
 ## `status`
@@ -630,16 +634,21 @@ Usage:  watson stop [OPTIONS]
 
 Stop monitoring time for the current project.
 
+If '--at' option is given, the provided stopping time is used. The
+specified time must be after the begin of the to be ended frame and must
+not be in the future.
+
 Example:
 
 
-    $ watson stop
-    Stopping project apollo11, started a minute ago. (id: e7ccd52)
+    $ watson stop --at 13:37
+    Stopping project apollo11, started an hour ago and stopped 30 minutes ago. (id: e9ccd52)
 
 ### Options
 
 Flag | Help
 -----|-----
+`--at TIME` | Stop frame at this time. Must be in (YYYY-MM-DDT)?HH:MM(:SS)? format.
 `--help` | Show this message and exit.
 
 ## `sync`

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -271,6 +271,15 @@ my project = A B
     assert watson.current['tags'] == ['C', 'D', 'A', 'B']
 
 
+def test_start_nogap(mock, watson):
+
+    watson.start('foo')
+    watson.stop()
+    watson.start('bar', gap=False)
+
+    assert watson.frames[-1].stop == watson.current['start']
+
+
 # stop
 
 def test_stop_started_project(watson):
@@ -302,6 +311,24 @@ def test_stop_started_project_without_tags(watson):
 def test_stop_no_project(watson):
     with pytest.raises(WatsonError):
         watson.stop()
+
+
+def test_stop_started_project_at(watson):
+    watson.start('foo')
+    now = arrow.now()
+
+    with pytest.raises(ValueError):
+        time_str = '1970-01-01T00:00'
+        time_obj = arrow.get(time_str)
+        watson.stop(stop_at=time_obj)
+
+    with pytest.raises(ValueError):
+        time_str = '2999-31-12T23:59'
+        time_obj = arrow.get(time_str)
+        watson.stop(stop_at=time_obj)
+
+    watson.stop(stop_at=now)
+    assert watson.frames[-1].stop == now
 
 
 # cancel

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import operator
 import os
+import re
 
 from dateutil import tz
 from functools import reduce
@@ -68,7 +69,33 @@ class DateParamType(click.ParamType):
             return date
 
 
+class TimeParamType(click.ParamType):
+    name = 'time'
+
+    def convert(self, value, param, ctx):
+        if isinstance(value, arrow.Arrow):
+            return value
+
+        date_pattern = r'\d{4}-\d\d-\d\d'
+        time_pattern = r'\d\d:\d\d(:\d\d)?'
+
+        if re.match('^{time_pat}$'.format(time_pat=time_pattern), value):
+            cur_date = arrow.now().date().isoformat()
+            cur_time = '{date}T{time}'.format(date=cur_date, time=value)
+        elif re.match('^{date_pat}T{time_pat}'.format(
+                date_pat=date_pattern, time_pat=time_pattern), value):
+            cur_time = value
+        else:
+            errmsg = ('Could not parse time.'
+                      'Please specify in (YYYY-MM-DDT)?HH:MM(:SS)? format.')
+            raise WatsonCliError(errmsg)
+
+        local_tz = tz.tzlocal()
+        return arrow.get(cur_time).replace(tzinfo=local_tz)
+
+
 Date = DateParamType()
+Time = TimeParamType()
 
 
 @click.group()
@@ -107,11 +134,11 @@ def help(ctx, command):
     click.echo(cmd.get_help(ctx))
 
 
-def _start(watson, project, tags, restart=False):
+def _start(watson, project, tags, restart=False, gap=True):
     """
     Start project with given list of tags and save status.
     """
-    current = watson.start(project, tags, restart=restart)
+    current = watson.start(project, tags, restart=restart, gap=gap)
     click.echo(u"Starting project {}{} at {}".format(
         style('project', project),
         (" " if current['tags'] else "") + style('tags', current['tags']),
@@ -121,10 +148,13 @@ def _start(watson, project, tags, restart=False):
 
 
 @cli.command()
+@click.option('-g/-G', '--gap/--no-gap', 'gap_', is_flag=True, default=True,
+              help=("(Don't) leave gap between end time of previous project "
+                    "and start time of the current."))
 @click.argument('args', nargs=-1)
 @click.pass_obj
 @click.pass_context
-def start(ctx, watson, args):
+def start(ctx, watson, args, gap_=True):
     """
     Start monitoring time for the given project.
     You can add tags indicating more specifically what you are working on with
@@ -134,10 +164,13 @@ def start(ctx, watson, args):
     `options.stop_on_start` is set to a true value (`1`, `on`, `true` or
     `yes`), it is stopped before the new project is started.
 
+    If the '--no-gap' flag is given, the start time of the new project is set
+    to the stop time of the most recently stopped project.
+
     Example:
 
     \b
-    $ watson start apollo11 +module +brakes
+    $ watson start apollo11 +module +brakes --no-gap
     Starting project apollo11 [module, brakes] at 16:34
     """
     project = ' '.join(
@@ -147,31 +180,46 @@ def start(ctx, watson, args):
     # Parse all the tags
     tags = parse_tags(args)
 
+    if project and watson.is_started and not gap_:
+        current = watson.current
+        errmsg = ("Project {} is already started and '--no-gap' is passed. "
+                  "Please stop manually.")
+        raise _watson.WatsonError(errmsg.format(current['project']))
+
     if (project and watson.is_started and
             watson.config.getboolean('options', 'stop_on_start')):
         ctx.invoke(stop)
 
-    _start(watson, project, tags)
+    _start(watson, project, tags, gap=gap_)
 
 
-@cli.command()
+@cli.command(context_settings={'ignore_unknown_options': True})
+@click.option('--at', 'at_', type=Time, default=None,
+              help=('Stop frame at this time. Must be in '
+                    '(YYYY-MM-DDT)?HH:MM(:SS)? format.'))
 @click.pass_obj
-def stop(watson):
+def stop(watson, at_):
     """
     Stop monitoring time for the current project.
+
+    If '--at' option is given, the provided stopping time is used. The
+    specified time must be after the begin of the to be ended frame and must
+    not be in the future.
 
     Example:
 
     \b
-    $ watson stop
-    Stopping project apollo11, started a minute ago. (id: e7ccd52)
+    $ watson stop --at 13:37
+    Stopping project apollo11, started an hour ago and stopped 30 minutes ago. (id: e9ccd52) # noqa: E501
     """
-    frame = watson.stop()
-    click.echo(u"Stopping project {}{}, started {}. (id: {})".format(
+    frame = watson.stop(stop_at=at_)
+    output_str = u"Stopping project {}{}, started {} and stopped {}. (id: {})"
+    click.echo(output_str.format(
         style('project', frame.project),
         (" " if frame.tags else "") + style('tags', frame.tags),
         style('time', frame.start.humanize()),
-        style('short_id', frame.id)
+        style('time', frame.stop.humanize()),
+        style('short_id', frame.id),
     ))
     watson.save()
 


### PR DESCRIPTION
This commit adds the functionality needed to catch up on time tracking.

Take the scenario where you are engaged in several ad hoc discussions at
the desks of your colleagues, seamlessly transitioning into each other.
While you manage to remember when each discussion start, you still need
to enter those into Watson.

This commit gives you the tools to do so conveniently. You can use

    watson stop --at

to specify when a event stopped and

    watson start --no-gap

to instruct Watson to start the new event seamlessly to the one most
recently stopped. By this to catch up on your time tracking all you need
to do is to cycle through these two commands.