### PR TITLE
Enhance Bash completion (stop and rename)

### DIFF
--- a/watson.completion
+++ b/watson.completion
@@ -91,6 +91,9 @@ _watson_complete () {
               tags="$(watson tags | sed -e 's/ /\\\\ /g')"
               COMPREPLY=($(compgen -W "$tags" -- ${cur}))
               ;;
+            *)
+              COMPREPLY=($(compgen -W $'project\ntag' -- ${cur}))
+              ;;
           esac
           ;;
         restart)
@@ -116,6 +119,10 @@ _watson_complete () {
         status)
           COMPREPLY=($(compgen -W "-e --elapsed -p --project -t --tags" -- ${cur}))
           ;;
+        stop)
+          if [[ $COMP_CWORD -eq 2 ]]; then
+            COMPREPLY=($(compgen -W "--at" -- ${cur}))
+          fi
       esac
       ;;
   esac

--- a/watson.completion
+++ b/watson.completion
@@ -108,7 +108,13 @@ _watson_complete () {
           ;;
         start)
           local IFS=$'\n'
-          if [[ $COMP_CWORD -eq 2 ]]; then
+          prev="${COMP_WORDS[COMP_CWORD-1]}"
+          if [[ $prev == '-g' || $prev == '--gap' || $prev == '-G' || $prev == '--no-gap' ]]; then
+            prev_is_option="true"
+          else
+            prev_is_option="false"
+          fi
+          if [[ $COMP_CWORD -eq 2 || ($COMP_CWORD -eq 3 && $prev_is_option == "true") ]]; then
             projects="$(watson projects | sed -e 's/ /\\\\ /g')"
             COMPREPLY=($(compgen -W "$projects" -- ${cur}))
           else


### PR DESCRIPTION
The Bash completion for `watson stop` now gives a hint to '--at'.

The Bash completion for `watson rename` now completes prefixes to
'project' or 'tag'. This fixes #237.