### PR TITLE
Modify WATSON_DIR on virtualenv activation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ PIP ?= pip
 VENV = virtualenv
 VENV_ARGS = -p $(PYTHON)
 VENV_DIR = $(CURDIR)/.venv
+VENV_WATSON_DIR = $(CURDIR)/data
 
 all: install
 
 $(VENV_DIR): requirements-dev.txt
 	$(VENV) $(VENV_ARGS) "$(VENV_DIR)"
+	echo "export WATSON_DIR=\"$(VENV_WATSON_DIR)\"" >> "$(VENV_DIR)"/bin/activate
 	"$(VENV_DIR)"/bin/pip install -U setuptools wheel pip
 	"$(VENV_DIR)"/bin/pip install -Ur $<
 


### PR DESCRIPTION
I'm planning to contribute to watson, so I'm going through the repo and docs, trying to hack a bit in my local environment.

After reading the hack documentation and the issue #238 I think there is a potential risk of messing with your real watson data, which is not desired at all (although yes, I have backups :)

In this PR, I just make sure that `WATSON_DIR` will always be equal to `"$(watson_dir)/data"` when activating the virtualenv.

I can think of a couple of things against this PR: 
* The "data" directory name is only based on the comments of #238 but people could be using a different name. If this would be the case, it doesn't affect them because they're doing an export after activating the environment anyway.
* No documentation. I think the hack doc needs some work, but first PR #243 should be merged or rejected. After that, it would be nice to speak of the Makefile on that document, which would include a mention to this PR change. Also, adding Python3 support to the aforementioned Makefile could be interesting.

Any comments are welcomed!