### PR TITLE
Warn new project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for first day of the week configuration in reports and logs (#240)
 - Python 3.7 support (#241)
 - Add `start --no-gap` and `stop --at` options (#254)
-- `--confirm-new-project` and `--confirm-new-tag` options to `start`, `add`, `edit` commands (#275)
+- Add `--confirm-new-project` and `--confirm-new-tag` options to `start`, `add` and `edit` commands (#275)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for first day of the week configuration in reports and logs (#240)
 - Python 3.7 support (#241)
 - Add `start --no-gap` and `stop --at` options (#254)
+- `--confirm-new-project` and `--confirm-new-tag` options to `start`, `add`, `edit` commands (#275)
 
 ### Changed
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -26,8 +26,8 @@ Flag | Help
 -----|-----
 `-f, --from DATE` | Date and time of start of tracked activity  [required]
 `-t, --to DATE` | Date and time of end of tracked activity  [required]
-`--confirm-new-project` | Confirm addition of new project.
-`--confirm-new-tag` | Confirm creation of new tag.
+`-c, --confirm-new-project` | Confirm addition of new project.
+`-b, --confirm-new-tag` | Confirm creation of new tag.
 `--help` | Show this message and exit.
 
 ## `aggregate`
@@ -165,8 +165,8 @@ to `vim`, `nano` or `vi` (first one found) on all other systems.
 
 Flag | Help
 -----|-----
-`--confirm-new-project` | Confirm addition of new project.
-`--confirm-new-tag` | Confirm creation of new tag.
+`-c, --confirm-new-project` | Confirm addition of new project.
+`-b, --confirm-new-tag` | Confirm creation of new tag.
 `--help` | Show this message and exit.
 
 ## `frames`
@@ -595,8 +595,8 @@ Example:
 Flag | Help
 -----|-----
 `-g, --gap / -G, --no-gap` | (Don't) leave gap between end time of previous project and start time of the current.
-`--confirm-new-project` | Confirm addition of new project.
-`--confirm-new-tag` | Confirm creation of new tag.
+`-c, --confirm-new-project` | Confirm addition of new project.
+`-b, --confirm-new-tag` | Confirm creation of new tag.
 `--help` | Show this message and exit.
 
 ## `status`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -26,6 +26,8 @@ Flag | Help
 -----|-----
 `-f, --from DATE` | Date and time of start of tracked activity  [required]
 `-t, --to DATE` | Date and time of end of tracked activity  [required]
+`--confirm-new-project` | Confirm addition of new project.
+`--confirm-new-tag` | Confirm creation of new tag.
 `--help` | Show this message and exit.
 
 ## `aggregate`
@@ -163,6 +165,8 @@ to `vim`, `nano` or `vi` (first one found) on all other systems.
 
 Flag | Help
 -----|-----
+`--confirm-new-project` | Confirm addition of new project.
+`--confirm-new-tag` | Confirm creation of new tag.
 `--help` | Show this message and exit.
 
 ## `frames`
@@ -591,6 +595,8 @@ Example:
 Flag | Help
 -----|-----
 `-g, --gap / -G, --no-gap` | (Don't) leave gap between end time of previous project and start time of the current.
+`--confirm-new-project` | Confirm addition of new project.
+`--confirm-new-tag` | Confirm creation of new tag.
 `--help` | Show this message and exit.
 
 ## `status`
@@ -642,7 +648,7 @@ Example:
 
 
     $ watson stop --at 13:37
-    Stopping project apollo11, started an hour ago and stopped 30 minutes ago. (id: e9ccd52)
+    Stopping project apollo11, started an hour ago and stopped 30 minutes ago. (id: e9ccd52) # noqa: E501
 
 ### Options
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,10 +12,14 @@ except ImportError:
     from io import StringIO
 
 import pytest
+from unittest.mock import patch
+from click.exceptions import Abort
 from dateutil.tz import tzutc
 
+import watson
 from watson.utils import (apply_weekday_offset, get_start_time_for_period,
-                          make_json_writer, safe_save, parse_tags, PY2)
+                          make_json_writer, safe_save, parse_tags, PY2,
+                          confirm_project, confirm_tags)
 from . import mock_datetime
 
 
@@ -174,3 +178,45 @@ def test_safe_save_with_exception(config_dir):
 def test_parse_tags(args, parsed_tags):
     tags = parse_tags(args)
     assert tags == parsed_tags
+
+
+def test_confirm_project_existing_project_returns_true():
+    project = 'foo'
+    projects = ['foo', 'bar']
+    assert confirm_project(project, projects)
+
+
+@patch('click.confirm', return_value=True)
+def test_confirm_project_accept_returns_true(confirm):
+    project = 'baz'
+    projects = ['foo', 'bar']
+    assert confirm_project(project, projects)
+
+
+@patch('watson.utils.click.confirm', side_effect=Abort)
+def test_confirm_project_reject_raises_abort(confirm):
+    project = 'baz'
+    projects = ['foo', 'bar']
+    with pytest.raises(Abort) as e:
+            confirm_project(project, projects)
+
+
+def test_confirm_tags_existing_tag_returns_true():
+    tags = ['a']
+    watson_tags = ['a', 'b']
+    assert confirm_tags(tags, watson_tags)
+
+
+@patch('watson.utils.click.confirm', return_value=True)
+def test_confirm_tags_accept_returns_true(confirm):
+    tags = ['c']
+    watson_tags = ['a', 'b']
+    assert confirm_tags(tags, watson_tags)
+
+
+@patch('watson.utils.click.confirm', side_effect=Abort)
+def test_confirm_tags_reject_raises_abort(confirm):
+    tags = ['c']
+    watson_tags = ['a', 'b']
+    with pytest.raises(Abort) as e:
+            confirm_project(tags, watson_tags)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,9 +18,16 @@ import pytest
 from click.exceptions import Abort
 from dateutil.tz import tzutc
 
-from watson.utils import (apply_weekday_offset, get_start_time_for_period,
-                          make_json_writer, safe_save, parse_tags, PY2,
-                          confirm_project, confirm_tags)
+from watson.utils import (
+    apply_weekday_offset,
+    confirm_project,
+    confirm_tags,
+    get_start_time_for_period,
+    make_json_writer,
+    safe_save,
+    parse_tags,
+    PY2,
+)
 from . import mock_datetime
 
 
@@ -183,23 +190,23 @@ def test_parse_tags(args, parsed_tags):
 
 def test_confirm_project_existing_project_returns_true():
     project = 'foo'
-    projects = ['foo', 'bar']
-    assert confirm_project(project, projects)
+    watson_projects = ['foo', 'bar']
+    assert confirm_project(project, watson_projects)
 
 
 @patch('click.confirm', return_value=True)
 def test_confirm_project_accept_returns_true(confirm):
     project = 'baz'
-    projects = ['foo', 'bar']
-    assert confirm_project(project, projects)
+    watson_projects = ['foo', 'bar']
+    assert confirm_project(project, watson_projects)
 
 
 @patch('watson.utils.click.confirm', side_effect=Abort)
 def test_confirm_project_reject_raises_abort(confirm):
     project = 'baz'
-    projects = ['foo', 'bar']
+    watson_projects = ['foo', 'bar']
     with pytest.raises(Abort):
-        confirm_project(project, projects)
+        confirm_project(project, watson_projects)
 
 
 def test_confirm_tags_existing_tag_returns_true():
@@ -208,14 +215,14 @@ def test_confirm_tags_existing_tag_returns_true():
     assert confirm_tags(tags, watson_tags)
 
 
-@patch('watson.utils.click.confirm', return_value=True)
+@patch('click.confirm', return_value=True)
 def test_confirm_tags_accept_returns_true(confirm):
     tags = ['c']
     watson_tags = ['a', 'b']
     assert confirm_tags(tags, watson_tags)
 
 
-@patch('watson.utils.click.confirm', side_effect=Abort)
+@patch('click.confirm', side_effect=Abort)
 def test_confirm_tags_reject_raises_abort(confirm):
     tags = ['c']
     watson_tags = ['a', 'b']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,13 +10,14 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import pytest
-from unittest.mock import patch
 from click.exceptions import Abort
 from dateutil.tz import tzutc
 
-import watson
 from watson.utils import (apply_weekday_offset, get_start_time_for_period,
                           make_json_writer, safe_save, parse_tags, PY2,
                           confirm_project, confirm_tags)
@@ -197,8 +198,8 @@ def test_confirm_project_accept_returns_true(confirm):
 def test_confirm_project_reject_raises_abort(confirm):
     project = 'baz'
     projects = ['foo', 'bar']
-    with pytest.raises(Abort) as e:
-            confirm_project(project, projects)
+    with pytest.raises(Abort):
+        confirm_project(project, projects)
 
 
 def test_confirm_tags_existing_tag_returns_true():
@@ -218,5 +219,5 @@ def test_confirm_tags_accept_returns_true(confirm):
 def test_confirm_tags_reject_raises_abort(confirm):
     tags = ['c']
     watson_tags = ['a', 'b']
-    with pytest.raises(Abort) as e:
-            confirm_project(tags, watson_tags)
+    with pytest.raises(Abort):
+        confirm_project(tags, watson_tags)

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -186,14 +186,16 @@ def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
     )
 
     # Confirm creation of new project if that option is set
-    if watson.config.getboolean('options', 'confirm_new_project') or confirm_new_project:
+    if (watson.config.getboolean('options', 'confirm_new_project') or
+            confirm_new_project):
         confirm_project(project, watson.projects)
 
     # Parse all the tags
     tags = parse_tags(args)
 
     # Confirm creation of new tag(s) if that option is set
-    if watson.config.getboolean('options', 'confirm_new_tag') or confirm_new_tag:
+    if (watson.config.getboolean('options', 'confirm_new_tag') or
+            confirm_new_tag):
         confirm_tags(tags, watson.tags)
 
     if project and watson.is_started and not gap_:
@@ -1031,14 +1033,16 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
     )
 
     # Confirm creation of new project if that option is set
-    if watson.config.getboolean('options', 'confirm_new_project') or confirm_new_project:
+    if (watson.config.getboolean('options', 'confirm_new_project') or
+            confirm_new_project):
         confirm_project(project, watson.projects)
 
     # Parse all the tags
     tags = parse_tags(args)
 
     # Confirm creation of new tag(s) if that option is set
-    if watson.config.getboolean('options', 'confirm_new_tag') or confirm_new_tag:
+    if (watson.config.getboolean('options', 'confirm_new_tag') or
+            confirm_new_tag):
         confirm_tags(tags, watson.tags)
 
     # add a new frame, call watson save to update state files
@@ -1123,11 +1127,13 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
             data = json.loads(output)
             project = data['project']
             # Confirm creation of new project if that option is set
-            if watson.config.getboolean('options', 'confirm_new_project') or confirm_new_project:
+            if (watson.config.getboolean('options', 'confirm_new_project') or
+                    confirm_new_project):
                 confirm_project(project, watson.projects)
             tags = data['tags']
             # Confirm creation of new tag(s) if that option is set
-            if watson.config.getboolean('options', 'confirm_new_tag') or confirm_new_tag:
+            if (watson.config.getboolean('options', 'confirm_new_tag') or
+                    confirm_new_tag):
                 confirm_tags(tags, watson.tags)
             start = arrow.get(data['start'], datetime_format).replace(
                 tzinfo=local_tz).to('utc')

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -164,9 +164,9 @@ def _start(watson, project, tags, restart=False, gap=True):
               help=("(Don't) leave gap between end time of previous project "
                     "and start time of the current."))
 @click.argument('args', nargs=-1)
-@click.option('--confirm-new-project', is_flag=True, default=False,
+@click.option('-c', '--confirm-new-project', is_flag=True, default=False,
               help="Confirm addition of new project.")
-@click.option('--confirm-new-tag', is_flag=True, default=False,
+@click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
               help="Confirm creation of new tag.")
 @click.pass_obj
 @click.pass_context

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1020,9 +1020,9 @@ def frames(watson):
               help="Date and time of start of tracked activity")
 @click.option('-t', '--to', required=True, type=Date,
               help="Date and time of end of tracked activity")
-@click.option('--confirm-new-project', is_flag=True, default=False,
+@click.option('-c', '--confirm-new-project', is_flag=True, default=False,
               help="Confirm addition of new project.")
-@click.option('--confirm-new-tag', is_flag=True, default=False,
+@click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
               help="Confirm creation of new tag.")
 @click.pass_obj
 def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
@@ -1068,9 +1068,9 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
 
 
 @cli.command(context_settings={'ignore_unknown_options': True})
-@click.option('--confirm-new-project', is_flag=True, default=False,
+@click.option('-c', '--confirm-new-project', is_flag=True, default=False,
               help="Confirm addition of new project.")
-@click.option('--confirm-new-tag', is_flag=True, default=False,
+@click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
               help="Confirm creation of new tag.")
 @click.argument('id', required=False)
 @click.pass_obj

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -15,10 +15,18 @@ import click
 
 from . import watson as _watson
 from .frames import Frame
-from .utils import (apply_weekday_offset, format_timedelta,
-                    get_frame_from_argument, get_start_time_for_period,
-                    options, safe_save, sorted_groupby, style, parse_tags,
-                    confirm_project, confirm_tags)
+from .utils import (
+    apply_weekday_offset,
+    confirm_project,
+    confirm_tags,
+    format_timedelta,
+    get_frame_from_argument,
+    get_start_time_for_period,
+    options, safe_save,
+    sorted_groupby,
+    style,
+    parse_tags,
+)
 
 
 class MutuallyExclusiveOption(click.Option):

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -23,12 +23,12 @@ except NameError:
     text_type = str
 
 
-def confirm_project(project, projects):
+def confirm_project(project, watson_projects):
     """
     Ask user to confirm creation of a new project
     Returns True on accept and raises click.exceptions.Abort on reject
     """
-    if project not in projects:
+    if project not in watson_projects:
         msg = "Project '%s' does not exist yet. Create it?" % project
         click.confirm(msg, abort=True)
     return True
@@ -36,8 +36,8 @@ def confirm_project(project, projects):
 
 def confirm_tags(tags, watson_tags):
     """
-    Ask user to confirm creation of a new tag
-    Returns True on accept and raises click.exceptions.Abort on reject
+    Ask user to confirm creation of new tags (each separately)
+    Returns True if all accepted and raises click.exceptions.Abort on reject
     """
     for tag in tags:
         if tag not in watson_tags:

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -23,6 +23,29 @@ except NameError:
     text_type = str
 
 
+def confirm_project(watson, project, confirm_new_project):
+    # https://github.com/TailorDev/Watson/issues/191 - for project
+    if watson.config.getboolean('options',
+                                'confirm_new_project') or confirm_new_project:
+        if project not in watson.projects:
+            msg = "Project '%s' does not exist yet. Create it?" % project
+            if not click.confirm(msg, err=True):
+                click.echo("Aborting operation.", err=True)
+                sys.exit(1)
+
+
+def confirm_tags(watson, tags, confirm_new_tag):
+    # https://github.com/TailorDev/Watson/issues/191 - for tags
+    if watson.config.getboolean('options',
+                                'confirm_new_tag') or confirm_new_tag:
+        for tag in tags:
+            if tag not in watson.tags:
+                msg = "Tag '%s' does not exist yet. Create it?" % tag
+                if not click.confirm(msg, err=True):
+                    click.echo("Aborting operation.", err=True)
+                    sys.exit(1)
+
+
 def style(name, element):
     def _style_tags(tags):
         if not tags:

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -23,27 +23,27 @@ except NameError:
     text_type = str
 
 
-def confirm_project(watson, project, confirm_new_project):
-    # https://github.com/TailorDev/Watson/issues/191 - for project
-    if watson.config.getboolean('options',
-                                'confirm_new_project') or confirm_new_project:
-        if project not in watson.projects:
-            msg = "Project '%s' does not exist yet. Create it?" % project
-            if not click.confirm(msg, err=True):
-                click.echo("Aborting operation.", err=True)
-                sys.exit(1)
+def confirm_project(project, projects):
+    """
+    Ask user to confirm creation of a new project
+    Returns True on accept and raises click.exceptions.Abort on reject
+    """
+    if project not in projects:
+        msg = "Project '%s' does not exist yet. Create it?" % project
+        click.confirm(msg, abort=True)
+    return True
 
 
-def confirm_tags(watson, tags, confirm_new_tag):
-    # https://github.com/TailorDev/Watson/issues/191 - for tags
-    if watson.config.getboolean('options',
-                                'confirm_new_tag') or confirm_new_tag:
-        for tag in tags:
-            if tag not in watson.tags:
-                msg = "Tag '%s' does not exist yet. Create it?" % tag
-                if not click.confirm(msg, err=True):
-                    click.echo("Aborting operation.", err=True)
-                    sys.exit(1)
+def confirm_tags(tags, watson_tags):
+    """
+    Ask user to confirm creation of a new tag
+    Returns True on accept and raises click.exceptions.Abort on reject
+    """
+    for tag in tags:
+        if tag not in watson_tags:
+            msg = "Tag '%s' does not exist yet. Create it?" % tag
+            click.confirm(msg, abort=True)
+    return True
 
 
 def style(name, element):


### PR DESCRIPTION
A re-implementation of this PR: https://github.com/TailorDev/Watson/pull/218

Quoting:
```
In issue #191 possibility to configure Watson to warn about adding projects and/or tags that do not exist yet was requested.

This pull requests now implements this feature. By adding --confirm-new-project or --confirm-new-tag to start, add or edit commands this feature is enabled. By default --no-confirm-new-project and --no-confirm-new-tag are in effect. This feature can also be enabled by adding confirm_new_project = true and/or confirm_new_tag = true to Watson configuration file under 'options' section.
```

With the following changes to that PR:
Adds the missing unit tests.
Refactors to keep watson object separate from utils module.
Simplifies the confirm_ methods by letting click raise the Abort exception automatically if user rejects. 
Removes --no-confirm* cli options, as the default=False arg makes those options redundant. 
Update the docs

Closes #218 