### PR TITLE
Add support for returning frames partially within span in filter and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
 - Watson now suggests correct command if users make small typo (#318)
 
+
 ### Fixed
 
 - Stylize prompt to create new project or tag (#310).
 - Aggregate calculates wrong time if used with `--current` (#293)
 - The `start` command now correctly checks if project is empty (#322)
+- Aggregate ignores frames that crosses aggreagate boundary (#248)
 - The `report` and `aggregate` commands with `--json` option now correctly
   encode Arrow objects (#329)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
 - Watson now suggests correct command if users make small typo (#318)
 
-
 ### Fixed
 
 - Stylize prompt to create new project or tag (#310).

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -826,7 +826,7 @@ def test_report_current(mocker, config_dir):
         (3600 * 48, True, 3600.0),
     )
 )
-def test_report_include_partial_frames(mock, watson, date_as_unixtime,
+def test_report_include_partial_frames(mocker, watson, date_as_unixtime,
                                        include_partial, sum_):
     """Test report building with frames that cross report boundaries
 
@@ -844,7 +844,7 @@ def test_report_include_partial_frames(mock, watson, date_as_unixtime,
         ["cli"],
         1548797432
     ]])
-    mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
+    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
     date = arrow.get(date_as_unixtime)
     report = watson.report(
         from_=date, to=date, include_partial_frames=include_partial,

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -489,7 +489,7 @@ _SHORTCUT_OPTIONS_VALUES = {
 @catch_watson_error
 def report(watson, current, from_, to, projects, tags, ignore_projects,
            ignore_tags, year, month, week, day, luna, all, output_format,
-           pager, aggregated=False, include_partial_frames=False):
+           pager, aggregated=False, include_partial_frames=True):
     """
     Display a report of the time spent on each project.
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -489,7 +489,7 @@ _SHORTCUT_OPTIONS_VALUES = {
 @catch_watson_error
 def report(watson, current, from_, to, projects, tags, ignore_projects,
            ignore_tags, year, month, week, day, luna, all, output_format,
-           pager, aggregated=False):
+           pager, aggregated=False, include_partial_frames=False):
     """
     Display a report of the time spent on each project.
 
@@ -606,7 +606,8 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
     report = watson.report(from_, to, current, projects, tags,
                            ignore_projects, ignore_tags,
                            year=year, month=month, week=week, day=day,
-                           luna=luna, all=all)
+                           luna=luna, all=all,
+                           include_partial_frames=include_partial_frames)
 
     if 'json' in output_format and not aggregated:
         click.echo(json.dumps(report, indent=4, sort_keys=True,
@@ -825,7 +826,8 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
         output = ctx.invoke(report, current=current, from_=from_offset,
                             to=from_offset, projects=projects, tags=tags,
                             output_format=output_format,
-                            pager=pager, aggregated=True)
+                            pager=pager, aggregated=True,
+                            include_partial_frames=True)
 
         if 'json' in output_format:
             lines.append(output)

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -451,7 +451,8 @@ class Watson(object):
 
     def report(self, from_, to, current=None, projects=None, tags=None,
                ignore_projects=None, ignore_tags=None, year=None,
-               month=None, week=None, day=None, luna=None, all=None):
+               month=None, week=None, day=None, luna=None, all=None,
+               include_partial_frames=False):
         for start_time in (_ for _ in [day, week, month, year, luna, all]
                            if _ is not None):
             from_ = start_time
@@ -481,7 +482,7 @@ class Watson(object):
                 projects=projects or None, tags=tags or None,
                 ignore_projects=ignore_projects or None,
                 ignore_tags=ignore_tags or None,
-                span=span
+                span=span, include_partial_frames=include_partial_frames,
             ),
             operator.attrgetter('project')
         )


### PR DESCRIPTION
… wire it up for aggregate

This is an attempt at a fix for #248. It adds an ``include_partial_frames`` argument to ``Frames.filter`` which if set True, and given a span, will return pseudo frames for frames that cross the span boundaries or for frames that envelope the entire span. The pseudo frames are copies of the original frames but where the start and/or endpoint has been edited to show **the part** of the frame that is within the span.

The ``include_partial_frames`` argument, is a keyword argument with default value False, which means that backwards compatibility should be kept for all other function until it can be decided if they need partial frames as well. For now, it is only wired up for aggregate.

Critique welcome:
 * I'm not quite happy with the name of the argument, suggestions welcome
 * This somewhat removed the elegance of the old implementation of the filter function and it is possible that the _partially in_ semantics can be done cleverer. Let me know.

I'm happy to try and do a test for it, but I want to know if you are happy with the form before I do that.