### PR TITLE
Extend hack doc favoring existing Makefile usage

### DIFF
--- a/docs/contributing/hack.md
+++ b/docs/contributing/hack.md
@@ -2,43 +2,72 @@
 
 Ready to contribute? Here's how to set up *Watson* for local development.
 
+## Python requirements
+* Python (2/3) interpreter installed
+* `pip` tool to install package dependencies
+* `virtualenv` tool to create virtual environments
+
 ## Get started!
 
-1.  Fork the [Watson repository](https://github.com/TailorDev/Watson/) on GitHub.
-2.  Clone your fork locally:
+1. Fork the [Watson repository](https://github.com/TailorDev/Watson/) on GitHub.
+
+2. Clone your fork locally:
 
         $ git clone git@github.com:your_name_here/Watson.git
 
-3.  Install Watson locally:
+3. Create a virtual environment:
 
-        $ mkvirtualenv watson
         $ cd Watson
-        $ pip install -r requirements-dev.txt
-        $ python setup.py develop
+        $ make env
 
-4.  Create a branch for local development:
+    The Python version used will be the one accesible using the `python`
+    command in your shell.
 
-        $ git checkout -b name-of-your-bugfix-or-feature
+    To use a different Python version, define the `PYTHON` shell variable.
+    For example:
+
+        $ PYTHON=python3.5 make env
+
+4. Install dependencies and deploy Watson inside the virtual environment:
+
+        $ source .venv/bin/activate
+        (.venv) $ make install-dev
+
+5. Create a branch for local development:
+
+        (.venv) $ git checkout -b name-of-your-bugfix-or-feature
 
     Now you can make your changes locally.
 
-5.  When you're done making changes, check that your changes pass the tests
+    _Notes:_
+
+    - The files you need to edit to change watson's behavior are located in the
+      `watson/` subfolder.
+    - Every time you run `watson` inside the virtual environment, the source
+      code inside the `watson/` subfolder will be used.
+    - To avoid messing with your real Watson data, watson will use `data/` as
+      the [application folder](../user-guide/configuration/#application-folder)
+      inside the virtual environment. You can run `watson projects` to check
+      that your real projects are not shown.
+
+6. When you're done making changes, check that your changes pass the tests
     (see [Run the tests](#run-the-tests)):
 
-        $ tox
+        (.venv) $ tox
 
-6. If you have added a new command or updated/fixed docstrings, please update the documentation:
+7. If you have added a new command or updated/fixed docstrings, please update
+    the documentation:
 
-        $ make docs
+        (.venv) $ make docs
 
-7.  Commit your changes and push your branch to GitHub:
+8. Commit your changes and push your branch to GitHub:
 
         $ git add .
         $ git commit -m "Your detailed description of your changes."
         $ git push -u origin name-of-your-bugfix-or-feature
 
-8.  After [reading this](./pr-guidelines.md), submit a pull request through the GitHub website.
-
+9. After [reading this](./pr-guidelines.md), submit a pull request through the
+    GitHub website.
 
 <a href="#run-the-tests"></a>
 ## Run the tests


### PR DESCRIPTION
I've tried to simplify the hack doc (`docs/contributing/hack.md`) but also extend it where I found it appropriate for a beginner/newcomer.

These are the changes:

- Add more info for newcomers and beginners extracted from #243

- Avoid using a higher-level virtualenv manager (like virtualenvwrapper
or pipenv) to simplify the doc and to benefit from the existing Makefile

- Explain why and where watson searches for config/data after #273

- Add a Python requirements section

- Unify maximum line length to 80 characters

Suggestions/comments/critiques are more than welcomed! :)