### PR TITLE
Support CSV output where JSON is allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CSV output format support for `report`, `log` and `aggregate` commands
+  using the `--csv/-s` command line option flag (#281).
+
 ### Fixed
 
-- Update zsh shell completion (#264)
+- Update zsh shell completion (#264).
 
 ### Removed
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -52,8 +52,10 @@ projects or tags to the report.
 If you are outputting to the terminal, you can selectively enable a pager
 through the `--pager` option.
 
-You can change the output format for the report from *plain text* to *JSON*
-by using the `--json` option.
+You can change the output format from *plain text* to *JSON* using the
+`--json` option or to *CSV* using the `--csv` option. Only one  of these
+two options can be used at once.
+
 
 Example:
 
@@ -86,6 +88,21 @@ Example:
     Wed 21 November 2018 - 01m 17s
       watson - 01m 17s
             [docs     01m 17s]
+    
+    $ watson aggregate --csv
+    from,to,project,tag,time
+    2018-11-14 00:00:00,2018-11-14 23:59:59,watson,,20542.0
+    2018-11-14 00:00:00,2018-11-14 23:59:59,watson,features,2046.0
+    2018-11-14 00:00:00,2018-11-14 23:59:59,watson,docs,18496.0
+    2018-11-19 00:00:00,2018-11-19 23:59:59,watson,,21532.0
+    2018-11-19 00:00:00,2018-11-19 23:59:59,watson,features,4323.0
+    2018-11-19 00:00:00,2018-11-19 23:59:59,watson,docs,17209.0
+    2018-11-20 00:00:00,2018-11-20 23:59:59,watson,,10235.0
+    2018-11-20 00:00:00,2018-11-20 23:59:59,watson,features,917.0
+    2018-11-20 00:00:00,2018-11-20 23:59:59,watson,docs,5863.0
+    2018-11-20 00:00:00,2018-11-20 23:59:59,watson,website,3455.0
+    2018-11-21 00:00:00,2018-11-21 23:59:59,watson,,77.0
+    2018-11-21 00:00:00,2018-11-21 23:59:59,watson,docs,77.0
 
 ### Options
 
@@ -96,7 +113,8 @@ Flag | Help
 `-t, --to DATE` | The date at which the report should stop (inclusive). Defaults to tomorrow.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`-j, --json` | Format the report in JSON instead of plain text
+`-j, --json` | Format output in JSON instead of plain text
+`-s, --csv` | Format output in CSV instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
 
@@ -232,6 +250,10 @@ You can limit the log to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
 projects or tags to the log.
 
+You can change the output format from *plain text* to *JSON* using the
+`--json` option or to *CSV* using the `--csv` option. Only one  of these
+two options can be used at once.
+
 Example:
 
 
@@ -260,6 +282,14 @@ Example:
     Wednesday 16 April 2014 (5h 19m 18s)
             02cb269  09:53 to 12:43   2h 50m 07s  apollo11  [wheels]
             1070ddb  13:48 to 16:17   2h 29m 11s  voyager1  [antenna, sensors]
+    
+    $ watson log --from 2014-04-16 --to 2014-04-17 --csv
+    id,start,stop,project,tags
+    a96fcde,2014-04-17 09:15,2014-04-17 09:43,hubble,"lens, camera, transmission"
+    5e91316,2014-04-17 10:19,2014-04-17 12:59,hubble,"camera, transmission"
+    761dd51,2014-04-17 14:42,2014-04-17 15:54,voyager1,antenna
+    02cb269,2014-04-16 09:53,2014-04-16 12:43,apollo11,wheels
+    1070ddb,2014-04-16 13:48,2014-04-16 16:17,voyager1,"antenna, sensors"
 
 ### Options
 
@@ -276,7 +306,8 @@ Flag | Help
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`-j, --json` | Format the log in JSON instead of plain text
+`-j, --json` | Format output in JSON instead of plain text
+`-s, --csv` | Format output in CSV instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
 
@@ -439,7 +470,8 @@ If you are outputting to the terminal, you can selectively enable a pager
 through the `--pager` option.
 
 You can change the output format for the report from *plain text* to *JSON*
-by using the `--json` option.
+using the `--json` option or to *CSV* using the `--csv` option. Only one
+of these two options can be used at once.
 
 Example:
 
@@ -507,6 +539,15 @@ Example:
             "to": "2016-02-28T23:59:59.999999-08:00"
         }
     }
+    
+    $ watson report --from 2014-04-01 --to 2014-04-30 --project apollo11 --csv
+    from,to,project,tag,time
+    2014-04-01 00:00:00,2014-04-30 23:59:59,apollo11,,48140.0
+    2014-04-01 00:00:00,2014-04-30 23:59:59,apollo11,brakes,28421.0
+    2014-04-01 00:00:00,2014-04-30 23:59:59,apollo11,module,27701.0
+    2014-04-01 00:00:00,2014-04-30 23:59:59,apollo11,reactor,30950.0
+    2014-04-01 00:00:00,2014-04-30 23:59:59,apollo11,steering,38017.0
+    2014-04-01 00:00:00,2014-04-30 23:59:59,apollo11,wheels,36695.0
 
 ### Options
 
@@ -523,7 +564,8 @@ Flag | Help
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`-j, --json` | Format the report in JSON instead of plain text
+`-j, --json` | Format output in JSON instead of plain text
+`-s, --csv` | Format output in CSV instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
 `--help` | Show this message and exit.
 


### PR DESCRIPTION
In response to #256, which seems like an interesting use case to me, I've started to implement CSV format support in the same places where JSON is currently allowed (log/report/aggregate).

Some things are still missing, but I've created the PR to get early feedback (as suggested in the guidelines :).

## TODO
- [x] `MutuallyExclusiveOption` prints an invalid error message when specifying an option internal name, which is the case of `-j/--json` (i.e. `format_json`).
  * Handled in commit 0c7a803
- [x] Decide whether `--format` should be added (as discussed on #102).
  * After solving the previous point, it seems OK to have two different options for each of the two formats (i.e. json and csv), given that the plain format is the default and is hidden from the user.
- [x] Add tests
- [x] Document new command option(s) in `cli.py`
- [x] Add docstrings to new functions in `utils.py`

## Cli options
* Output formats for commands `log`, `report` and `aggregate`:
```
$ watson cmd --csv   # new: outputs a csv text as described below
$ watson cmd --json  # old: outputs a json in the same format as before
$ watson cmd --plain # new: this option is hidden in help/docs
                     # because it's the default output format
```
* Handling mutually exclusive options:
```
$ watson cmd --csv --json
Error: The following options are mutually exclusive: `--json`, `--csv`

$ watson report --luna --week
Error: The following options are mutually exclusive: `--all`, `--luna`, `--year`, `--week`, `--month`, `--day`
```

## CSV format
### Design decisions
* The generated output should contain, explicitly or implicitly, the same data available in the plain text format.
* Python `csv` classes are instantiated with the [default dialect, i.e. Excel](https://docs.python.org/3/library/csv.html#csv.DictWriter).
* Dates and times are formatted in a way that Excel can handle them (`yyyy-MM-dd HH:mm:ss` [according to this link](https://stackoverflow.com/questions/804118/best-timestamp-format-for-csv-excel))

### Examples
`$ watson log --csv`

```
id,start,stop,project,tags
b19d6b,2019-05-02 11:00:00,2019-05-02 13:02:34,project-2,
0ba222,2019-05-02 13:23:15,2019-05-02 14:31:25,project-2,
95c58c,2019-05-02 15:27:26,2019-05-02 20:47:36,project-2,
1f6adf,2019-05-06 15:37:38,2019-05-06 16:07:08,project-1,"tag-1, tag-2"
733381,2019-05-06 23:01:08,2019-05-06 23:26:37,project-3,"tag-3, tag-5"
e33ed7,2019-05-07 11:47:40,2019-05-07 14:06:50,project-3,"tag-3, tag-5"
1b2b89,2019-05-07 18:39:54,2019-05-07 18:57:59,project-4,"tag-5, tag-6, tag-7"
f9beb5,2019-05-07 19:14:14,2019-05-07 19:47:08,project-5,"tag-3, tag-5"
ed494a,2019-05-08 12:45:35,2019-05-08 13:00:37,project-4,"tag-5, tag-6, tag-7"
02da6f,2019-05-09 10:21:27,2019-05-09 13:19:22,project-3,"tag-3, tag-5"
45351e,2019-05-09 16:08:15,2019-05-09 19:23:15,project-3,"tag-3, tag-5"
4616a7,2019-05-09 19:13:15,2019-05-09 19:23:23,project-1,tag-1
8f4121,2019-05-09 19:23:44,2019-05-09 19:23:49,project-1,tag-2
980336,2019-05-09 19:30:16,2019-05-09 19:33:19,project-3,
```

`$ watson report --csv`
```
from,to,project,tag,time
2019-05-02 00:00:00,2019-05-09 23:59:59,project-1,,2383.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-1,tag-1,2378.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-1,tag-2,1775.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-2,,30654.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-3,,32437.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-3,tag-3,32254.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-3,tag-5,32254.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-4,,1987.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-4,tag-5,1987.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-4,tag-6,1987.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-4,tag-7,1987.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-5,,1974.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-5,tag-3,1974.0
2019-05-02 00:00:00,2019-05-09 23:59:59,project-5,tag-5,1974.0
```

`$ watson aggregate --csv`
```
from,to,project,tag,time
2019-05-02 00:00:00,2019-05-02 23:59:59,project-2,,30654.0
2019-05-06 00:00:00,2019-05-06 23:59:59,project-1,,1770.0
2019-05-06 00:00:00,2019-05-06 23:59:59,project-1,tag-1,1770.0
2019-05-06 00:00:00,2019-05-06 23:59:59,project-1,tag-2,1770.0
2019-05-06 00:00:00,2019-05-06 23:59:59,project-3,,1529.0
2019-05-06 00:00:00,2019-05-06 23:59:59,project-3,tag-3,1529.0
2019-05-06 00:00:00,2019-05-06 23:59:59,project-3,tag-5,1529.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-3,,8350.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-3,tag-3,8350.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-3,tag-5,8350.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-4,,1085.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-4,tag-5,1085.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-4,tag-6,1085.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-4,tag-7,1085.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-5,,1974.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-5,tag-3,1974.0
2019-05-07 00:00:00,2019-05-07 23:59:59,project-5,tag-5,1974.0
2019-05-08 00:00:00,2019-05-08 23:59:59,project-4,,902.0
2019-05-08 00:00:00,2019-05-08 23:59:59,project-4,tag-5,902.0
2019-05-08 00:00:00,2019-05-08 23:59:59,project-4,tag-6,902.0
2019-05-08 00:00:00,2019-05-08 23:59:59,project-4,tag-7,902.0
2019-05-09 00:00:00,2019-05-09 23:59:59,project-1,,613.0
2019-05-09 00:00:00,2019-05-09 23:59:59,project-1,tag-1,608.0
2019-05-09 00:00:00,2019-05-09 23:59:59,project-1,tag-2,5.0
2019-05-09 00:00:00,2019-05-09 23:59:59,project-3,,22558.0
2019-05-09 00:00:00,2019-05-09 23:59:59,project-3,tag-3,22375.0
2019-05-09 00:00:00,2019-05-09 23:59:59,project-3,tag-5,22375.0
```
