### PR TITLE
Status: elapsed time in minutes, not humanize()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ pip-log.txt
 *.sublime-workspace
 *.swp
 *.sw[po]
+data

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -329,8 +329,10 @@ def cancel(watson):
               help="only show tags")
 @click.option('-e', '--elapsed', is_flag=True,
               help="only show time elapsed")
+@click.option('-m', '--elapsedminutes', is_flag=True,
+              help="only show time elapsed in minutes")
 @click.pass_obj
-def status(watson, project, tags, elapsed):
+def status(watson, project, tags, elapsed, elapsedminutes):
     """
     Display when the current project was started and the time spent since.
 
@@ -371,6 +373,12 @@ def status(watson, project, tags, elapsed):
     if elapsed:
         click.echo(u"{}".format(
             style('time', current['start'].humanize())
+        ))
+        return
+
+    if elapsedminutes:
+        click.echo(u"{}".format(
+            style('time', current['start'])
         ))
         return
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -378,7 +378,7 @@ def status(watson, project, tags, elapsed, elapsedminutes):
 
     if elapsedminutes:
         click.echo(u"{}".format(
-            style('time', current['start'])
+            style('time',str(int((arrow.utcnow() - current['start']).seconds/60)))
         ))
         return
 


### PR DESCRIPTION
I worked on a widget for the AwesomeWM window manager, which displays watson's status with an icon (if a frame is started, it's a "play" icon, if not it's a "stop" icon, like a music player), surrounded by a (partial) circle which is a (circular) progress bar (reaching the full circle after an hour).
I needed the value of the spent time in the frame, but parsing the result of "humanize()" (given by the `status` command) is not very convenient. I copied the current flag code and wrote a slightly different version, which outputs the duration with a single number, in minutes (which could then be tweaked in the widget to account for hours or days).

A better version would probably merge the `-e` and `-m` flag to allow a formatting string. 