### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,14 @@ language: python
 
 matrix:
     include:
-        - python: 3.4
+        - python: 3.7
           os: linux
-          dist: trusty
+          dist: xenial
           env: TOXENV=flake8
         - python: 2.7
           os: linux
           dist: trusty
           env: TOXENV=py27
-        - python: 3.4
-          os: linux
-          dist: trusty
-          env: TOXENV=py34
         - python: 3.5
           os: linux
           dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update zsh shell completion (#264)
 
+### Removed
+
+- Python 3.4 support (#286).
+
 ## [1.7.0] - 2019-03-25
 
 ### Added

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -8,7 +8,7 @@ Watson configuration and data are stored inside your user's application folder. 
 * **Windows**: `%appdata%\watson\config`, which usually expands to `C:\Users\<user>\AppData\Roaming\watson\config`
 * **Linux**: `~/.config/watson/config`
 
-The configuration file is a typical [python configuration (INI) file](https://docs.python.org/3.4/library/configparser.html#supported-ini-file-structure), that looks like:
+The configuration file is a typical [python configuration (INI) file](https://docs.python.org/3.7/library/configparser.html#supported-ini-file-structure), that looks like:
 
 ```ini
 [Simple Values]
@@ -55,7 +55,7 @@ empty string value here =
         # Did I mention we can indent comments, too?
 ```
 
-_This example configuration file has been taken from the [official python documentation](https://docs.python.org/3.4/library/configparser.html#supported-ini-file-structure)._
+_This example configuration file has been taken from the [official python documentation](https://docs.python.org/3.7/library/configparser.html#supported-ini-file-structure)._
 
 
 ## Editing

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py34,py35,py36,py37
+envlist = flake8,py27,py35,py36,py37
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Remove references to Python 3.4 in Travis and Tox config. Also in Python doc links in Watson documentation.

Tox was failing in Travis due to a critical error installing arrow. This was due to Python 3.4 support being deprecated since March 2019.

The error was:

> ERROR: arrow requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.6

A warning message is shown when running Python 3.4:

> DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).