### PR TITLE
Add --ignore-project and --ignore-tag to report

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -462,9 +462,10 @@ respectively.
 The shortcut `--luna` sets the timespan to the current moon cycle with
 the last full moon marking the start of the cycle.
 
-You can limit the report to a project or a tag using the `--project` and
-`--tag` options. They can be specified several times each to add multiple
-projects or tags to the report.
+You can limit the report to a project or a tag using the `--project`,
+`--tag`, `--ignore-project` and `--ignore-tag` options. They can be
+specified several times each to add or ignore multiple projects or
+tags to the report.
 
 If you are outputting to the terminal, you can selectively enable a pager
 through the `--pager` option.
@@ -564,6 +565,8 @@ Flag | Help
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`--ignore-project TEXT` | Reports activity for all project but the given ones. You can ignore several projects by using the option multiple times. Any given project will be ignored
+`--ignore-tag TEXT` | Reports activity for all tags but the given ones. You can ignore several tags by using the option multiple times. Any given tag will be ignored
 `-j, --json` | Format output in JSON instead of plain text
 `-s, --csv` | Format output in CSV instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -565,7 +565,7 @@ Flag | Help
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`--ignore-project TEXT` | Reports activity for all project but the given ones. You can ignore several projects by using the option multiple times. Any given project will be ignored
+`--ignore-project TEXT` | Reports activity for all projects but the given ones. You can ignore several projects by using the option multiple times. Any given project will be ignored
 `--ignore-tag TEXT` | Reports activity for all tags but the given ones. You can ignore several tags by using the option multiple times. Any given tag will be ignored
 `-j, --json` | Format output in JSON instead of plain text
 `-s, --csv` | Format output in CSV instead of plain text

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -889,13 +889,13 @@ def test_add_failure(mock, watson):
 
 
 def test_validate_report_options(mock, watson):
-    assert not watson._validate_report_options(["project_foo"], None)
-    assert not watson._validate_report_options(None, ["project_foo"])
-    assert watson._validate_report_options(["project_foo"], ["project_foo"])
+    assert watson._validate_report_options(["project_foo"], None)
+    assert watson._validate_report_options(None, ["project_foo"])
     assert not watson._validate_report_options(["project_foo"],
-                                               ["project_bar"])
-    assert watson._validate_report_options(["project_foo", "project_bar"],
-                                           ["project_foo"])
-    assert watson._validate_report_options(["project_foo", "project_bar"],
-                                           ["project_foo", "project_bar"])
-    assert not watson._validate_report_options(None, None)
+                                               ["project_foo"])
+    assert watson._validate_report_options(["project_foo"], ["project_bar"])
+    assert not watson._validate_report_options(["project_foo", "project_bar"],
+                                               ["project_foo"])
+    assert not watson._validate_report_options(["project_foo", "project_bar"],
+                                               ["project_foo", "project_bar"])
+    assert watson._validate_report_options(None, None)

--- a/watson.fish
+++ b/watson.fish
@@ -82,12 +82,31 @@ end
 
 # ungrouped
 complete -f -c watson -n '__fish_watson_needs_sub' -a cancel -d "Cancel the last start command"
-complete -f -c watson -n '__fish_watson_needs_sub' -a stop -d " Stop monitoring time for the current project"
 complete -f -c watson -n '__fish_watson_needs_sub' -a frames -d "Display the list of all frame IDs"
 complete -f -c watson -n '__fish_watson_needs_sub' -a help -d "Display help information"
 complete -f -c watson -n '__fish_watson_needs_sub' -a projects -d "Display the list of projects"
-complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list of tags"
 complete -f -c watson -n '__fish_watson_needs_sub' -a sync -d "sync your work with $url"
+complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list of tags"
+
+# add
+complete -f -c watson -n '__fish_watson_needs_sub' -a add -d "Add time for project with tag(s) that was not tracked live"
+complete -f -c watson -n '__fish_watson_using_command add' -s f -l from -d "Start date for add"
+complete -f -c watson -n '__fish_watson_has_from add' -s t -l to -d "end date for add"
+complete -f -c watson -n '__fish_watson_using_command add' -s c -l confirm-new-project -d "Confirm addition of new project"
+complete -f -c watson -n '__fish_watson_using_command add' -s b -l confirm-new-tag -d "Confirm addition of new tag"
+
+# aggregate
+complete -f -c watson -n '__fish_watson_needs_sub' -a aggregate -d "Display a report of the time spent on each project aggregated by day"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s c -l current -d "include the running frame"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s C -l no-current -d "exclude the running frame (default)"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s f -l from -d "Start date for aggregate"
+complete -f -c watson -n '__fish_watson_has_from aggregate' -s t -l to -d "end date for aggregate"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s p -l project -d "restrict to project" -a "(__fish_watson_get_projects)"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s T -l tag -d "restrict to tag" -a "(__fish_watson_get_tags)"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s j -l json -d "output json"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s s -l csv -d "output csv"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s g -l pager -d "view through pager"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s G -l no-pager -d "don't vew through pager"
 
 # config
 complete -f -c watson -n '__fish_watson_needs_sub' -a config -d "Get and set configuration options"
@@ -105,12 +124,14 @@ complete -f -c watson -n '__fish_watson_using_command log' -s f -l from -d "Star
 complete -f -c watson -n '__fish_watson_has_from log' -s t -l to -d "end date for log"
 complete -f -c watson -n '__fish_watson_using_command log' -s y -l year -d "show the last year"
 complete -f -c watson -n '__fish_watson_using_command log' -s m -l month -d "show the last month"
+complete -f -c watson -n '__fish_watson_using_command log' -s l -l luna -d "show the last lunar cycle"
 complete -f -c watson -n '__fish_watson_using_command log' -s w -l week -d "show week-to-day"
 complete -f -c watson -n '__fish_watson_using_command log' -s d -l day -d "show today"
 complete -f -c watson -n '__fish_watson_using_command log' -s a -l all -d "show all"
 complete -f -c watson -n '__fish_watson_using_command log' -s p -l project -d "restrict to project" -a "(__fish_watson_get_projects)"
 complete -f -c watson -n '__fish_watson_using_command log' -s T -l tag -d "restrict to tag" -a "(__fish_watson_get_tags)"
 complete -f -c watson -n '__fish_watson_using_command log' -s j -l json -d "output json"
+complete -f -c watson -n '__fish_watson_using_command log' -s s -l csv -d "output csv"
 complete -f -c watson -n '__fish_watson_using_command log' -s g -l pager -d "view through pager"
 complete -f -c watson -n '__fish_watson_using_command log' -s G -l no-pager -d "don't vew through pager"
 
@@ -135,15 +156,18 @@ complete -f -c watson -n '__fish_watson_using_command report' -s f -l from -d "S
 complete -f -c watson -n '__fish_watson_has_from report' -s t -l to -d "end date for report"
 complete -f -c watson -n '__fish_watson_using_command report' -s y -l year -d "show the last year"
 complete -f -c watson -n '__fish_watson_using_command report' -s m -l month -d "show the last month"
+complete -f -c watson -n '__fish_watson_using_command report' -s l -l luna -d "show the last lunar cycle"
 complete -f -c watson -n '__fish_watson_using_command report' -s w -l week -d "show week-to-day"
 complete -f -c watson -n '__fish_watson_using_command report' -s d -l day -d "show today"
 complete -f -c watson -n '__fish_watson_using_command report' -s a -l all -d "show all"
 complete -f -c watson -n '__fish_watson_using_command report' -s p -l project -d "restrict to project" -a "(__fish_watson_get_projects)"
 complete -f -c watson -n '__fish_watson_using_command report' -s T -l tag -d "restrict to tag" -a "(__fish_watson_get_tags)"
 complete -f -c watson -n '__fish_watson_using_command report' -s j -l json -d "output json"
+complete -f -c watson -n '__fish_watson_using_command report' -s s -l csv -d "output csv"
 complete -f -c watson -n '__fish_watson_using_command report' -s g -l pager -d "view through pager"
 complete -f -c watson -n '__fish_watson_using_command report' -s G -l no-pager -d "don't vew through pager"
 
+# restart
 complete -f -c watson -n '__fish_watson_needs_sub' -a restart -d "Restart monitoring time for a stopped project"
 complete -f -c watson -n '__fish_watson_using_command restart' -s s -l stop -d "stop running project"
 complete -f -c watson -n '__fish_watson_using_command restart' -s S -l no-stop -d "do not stop running project"
@@ -159,3 +183,7 @@ complete -f -c watson -n '__fish_watson_needs_sub' -a status -d "Display when th
 complete -f -c watson -n '__fish_watson_using_command status' -s p -l project -d "only show project"
 complete -f -c watson -n '__fish_watson_using_command status' -s t -l tags -d "only show tags"
 complete -f -c watson -n '__fish_watson_using_command status' -s e -l elapsed -d "only show elapsed time"
+
+# stop
+complete -f -c watson -n '__fish_watson_needs_sub' -a stop -d "Stop monitoring time for the current project"
+complete -f -c watson -n '__fish_watson_using_command stop' -l at -d "Stop frame at this time (YYYY-MM-DDT)?HH:MM(:SS)?"

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -446,7 +446,7 @@ _SHORTCUT_OPTIONS_VALUES = {
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.option('--ignore-project', 'ignore_projects', multiple=True,
-              help="Reports activity for all project but the given ones. You "
+              help="Reports activity for all projects but the given ones. You "
               "can ignore several projects by using the option multiple times. "
               "Any given project will be ignored")
 @click.option('--ignore-tag', 'ignore_tags', multiple=True,

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -447,8 +447,8 @@ _SHORTCUT_OPTIONS_VALUES = {
               "times")
 @click.option('--ignore-project', 'ignore_projects', multiple=True,
               help="Reports activity for all projects but the given ones. You "
-              "can ignore several projects by using the option multiple times. "
-              "Any given project will be ignored")
+              "can ignore several projects by using the option multiple "
+              "times. Any given project will be ignored")
 @click.option('--ignore-tag', 'ignore_tags', multiple=True,
               help="Reports activity for all tags but the given ones. You can "
               "ignore several tags by using the option multiple times. Any "

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -143,11 +143,20 @@ class Frames(object):
     def dump(self):
         return tuple(frame.dump() for frame in self._rows)
 
-    def filter(self, projects=None, tags=None, span=None):
+    def filter(
+        self,
+        projects=None,
+        tags=None,
+        ignore_projects=None,
+        ignore_tags=None,
+        span=None,
+    ):
         return (
             frame for frame in self._rows
             if (projects is None or frame.project in projects) and
+               (ignore_projects is None or frame.project not in ignore_projects) and
                (tags is None or any(tag in frame.tags for tag in tags)) and
+               (ignore_tags is None or any(tag not in frame.tags for tag in ignore_tags)) and
                (span is None or frame in span)
         )
 

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -158,7 +158,7 @@ class Frames(object):
                    or frame.project not in ignore_projects) and
                (tags is None or any(tag in frame.tags for tag in tags)) and
                (ignore_tags is None
-                   or any(tag not in frame.tags for tag in ignore_tags)) and
+                   or all(tag not in frame.tags for tag in ignore_tags)) and
                (span is None or frame in span)
         )
 

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -154,9 +154,11 @@ class Frames(object):
         return (
             frame for frame in self._rows
             if (projects is None or frame.project in projects) and
-               (ignore_projects is None or frame.project not in ignore_projects) and
+               (ignore_projects is None
+                   or frame.project not in ignore_projects) and
                (tags is None or any(tag in frame.tags for tag in tags)) and
-               (ignore_tags is None or any(tag not in frame.tags for tag in ignore_tags)) and
+               (ignore_tags is None
+                   or any(tag not in frame.tags for tag in ignore_tags)) and
                (span is None or frame in span)
         )
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -456,7 +456,7 @@ class Watson(object):
 
         if self._validate_report_options(projects, ignore_projects):
             raise WatsonError(
-                "given projects can't be ignore at the same time")
+                "given projects can't be ignored at the same time")
 
         if self._validate_report_options(tags, ignore_tags):
             raise WatsonError("given tags can't be ignored at the same time")

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -443,18 +443,25 @@ class Watson(object):
 
         return conflicting, merging
 
+    def _validate_report_options(self, filtrate, ignored):
+        return bool(filtrate and ignored and set(filtrate).intersection(set(ignored)))
+
     def report(self, from_, to, current=None, projects=None, tags=None,
-               year=None, month=None, week=None, day=None, luna=None,
-               all=None):
+               ignore_projects=None, ignore_tags=None, year=None,
+               month=None, week=None, day=None, luna=None, all=None):
         for start_time in (_ for _ in [day, week, month, year, luna, all]
                            if _ is not None):
             from_ = start_time
 
+        if self._validate_report_options(projects, ignore_projects):
+            raise WatsonError(
+                "given projects can't be ignore at the same time")
+
+        if self._validate_report_options(tags, ignore_tags):
+            raise WatsonError("given tags can't be ignored at the same time")
+
         if from_ > to:
             raise WatsonError("'from' must be anterior to 'to'")
-
-        if tags is None:
-            tags = []
 
         if self.current:
             if current or (current is None and
@@ -468,7 +475,10 @@ class Watson(object):
 
         frames_by_project = sorted_groupby(
             self.frames.filter(
-                projects=projects or None, tags=tags or None, span=span
+                projects=projects or None, tags=tags or None,
+                ignore_projects=ignore_projects or None,
+                ignore_tags=ignore_tags or None,
+                span=span
             ),
             operator.attrgetter('project')
         )
@@ -497,6 +507,9 @@ class Watson(object):
                 'time': delta.total_seconds(),
                 'tags': []
             }
+
+            if tags is None:
+                tags = []
 
             tags_to_print = sorted(
                 set(tag for frame in frames for tag in frame.tags

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -444,7 +444,7 @@ class Watson(object):
         return conflicting, merging
 
     def _validate_report_options(self, filtrate, ignored):
-        return bool(
+        return not bool(
             filtrate and ignored and set(filtrate).intersection(set(ignored)))
 
     def report(self, from_, to, current=None, projects=None, tags=None,
@@ -454,11 +454,11 @@ class Watson(object):
                            if _ is not None):
             from_ = start_time
 
-        if self._validate_report_options(projects, ignore_projects):
+        if not self._validate_report_options(projects, ignore_projects):
             raise WatsonError(
                 "given projects can't be ignored at the same time")
 
-        if self._validate_report_options(tags, ignore_tags):
+        if not self._validate_report_options(tags, ignore_tags):
             raise WatsonError("given tags can't be ignored at the same time")
 
         if from_ > to:

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -444,7 +444,8 @@ class Watson(object):
         return conflicting, merging
 
     def _validate_report_options(self, filtrate, ignored):
-        return bool(filtrate and ignored and set(filtrate).intersection(set(ignored)))
+        return bool(
+            filtrate and ignored and set(filtrate).intersection(set(ignored)))
 
     def report(self, from_, to, current=None, projects=None, tags=None,
                ignore_projects=None, ignore_tags=None, year=None,


### PR DESCRIPTION
Add two options to ignore a project or a tag when generating a report, in the same way you can select some. I've used some json formatting + `jq` magic to filter out some specific tags from things like daily standups/weekly reports but it was a bit of a monstrosity, to be honest.

```
$ watson log -G
Monday 24 June 2019 (07m 58s)
	357a688  20:37 to 20:38          48s                 test task
	3f75de7  20:38 to 20:38          19s    test task do not track  [donottrack]
	9d610c4  21:01 to 21:02      01m 15s               test task 2  [another_tag]
	8ff2773  21:02 to 21:08      05m 32s  test task 3 not to track  [another_tag, donottrack]
	276a964  23:24 to 23:24          04s                 test task  [second_time]

$ watson report -G --project "test task"
Tue 18 June 2019 -> Tue 25 June 2019

test task - 52s
	[second_time         04s]

$ watson report -G --ignore-project "test task"
Tue 18 June 2019 -> Tue 25 June 2019

test task 2 - 01m 15s
	[another_tag     01m 15s]

test task 3 not to track - 05m 32s
	[another_tag     05m 32s]
	[donottrack     05m 32s]

test task do not track - 19s
	[donottrack         19s]

Total: 07m 06s
$ watson report -G --project "test task" --project "test task 2"                  
Tue 18 June 2019 -> Tue 25 June 2019

test task - 52s
	[second_time         04s]

test task 2 - 01m 15s
	[another_tag     01m 15s]

Total: 02m 07s
$ watson report -G --project "test task" --project "test task 2" --ignore-project "test task 2"
Error: given projects can't be ignore at the same time
$ watson report -G --tag another_tag                             
Tue 18 June 2019 -> Tue 25 June 2019

test task 2 - 01m 15s
	[another_tag     01m 15s]

test task 3 not to track - 05m 32s
	[another_tag     05m 32s]

Total: 06m 47s
$ watson report -G --ignore-tag donottracc
Tue 18 June 2019 -> Tue 25 June 2019

test task - 52s
	[second_time         04s]

test task 2 - 01m 15s
	[another_tag     01m 15s]

test task 3 not to track - 05m 32s
	[another_tag     05m 32s]
	[donottrack     05m 32s]

test task do not track - 19s
	[donottrack         19s]

Total: 07m 58s
$ watson report -G --ignore-tag donottrack
Tue 18 June 2019 -> Tue 25 June 2019

test task - 52s
	[second_time         04s]

test task 2 - 01m 15s
	[another_tag     01m 15s]

Total: 02m 07s
$ watson report -G --tag another_tag --ignore-tag another_tag
Error: given tags can't be ignored at the same time

$ watson report -G -c --ignore-tag donottrack --ignore-tag another_tag
Thu 20 June 2019 -> Thu 27 June 2019

test task - 52s
	[second_time         04s]


```