### PR TITLE
Update fish completions

### DIFF
--- a/watson.fish
+++ b/watson.fish
@@ -103,6 +103,7 @@ complete -f -c watson -n '__fish_watson_has_from aggregate' -s t -l to -d "end d
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s p -l project -d "restrict to project" -a "(__fish_watson_get_projects)"
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s T -l tag -d "restrict to tag" -a "(__fish_watson_get_tags)"
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s j -l json -d "output json"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s s -l csv -d "output csv"
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s g -l pager -d "view through pager"
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s G -l no-pager -d "don't vew through pager"
 
@@ -128,6 +129,7 @@ complete -f -c watson -n '__fish_watson_using_command log' -s a -l all -d "show 
 complete -f -c watson -n '__fish_watson_using_command log' -s p -l project -d "restrict to project" -a "(__fish_watson_get_projects)"
 complete -f -c watson -n '__fish_watson_using_command log' -s T -l tag -d "restrict to tag" -a "(__fish_watson_get_tags)"
 complete -f -c watson -n '__fish_watson_using_command log' -s j -l json -d "output json"
+complete -f -c watson -n '__fish_watson_using_command log' -s s -l csv -d "output csv"
 complete -f -c watson -n '__fish_watson_using_command log' -s g -l pager -d "view through pager"
 complete -f -c watson -n '__fish_watson_using_command log' -s G -l no-pager -d "don't vew through pager"
 
@@ -158,6 +160,7 @@ complete -f -c watson -n '__fish_watson_using_command report' -s a -l all -d "sh
 complete -f -c watson -n '__fish_watson_using_command report' -s p -l project -d "restrict to project" -a "(__fish_watson_get_projects)"
 complete -f -c watson -n '__fish_watson_using_command report' -s T -l tag -d "restrict to tag" -a "(__fish_watson_get_tags)"
 complete -f -c watson -n '__fish_watson_using_command report' -s j -l json -d "output json"
+complete -f -c watson -n '__fish_watson_using_command report' -s s -l csv -d "output csv"
 complete -f -c watson -n '__fish_watson_using_command report' -s g -l pager -d "view through pager"
 complete -f -c watson -n '__fish_watson_using_command report' -s G -l no-pager -d "don't vew through pager"
 

--- a/watson.fish
+++ b/watson.fish
@@ -89,6 +89,18 @@ complete -f -c watson -n '__fish_watson_needs_sub' -a projects -d "Display the l
 complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list of tags"
 complete -f -c watson -n '__fish_watson_needs_sub' -a sync -d "sync your work with $url"
 
+# aggregate
+complete -f -c watson -n '__fish_watson_needs_sub' -a aggregate -d "Display a report of the time spent on each project aggregated by day."
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s c -l current -d "include the running frame"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s C -l no-current -d "exclude the running frame (default)"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s f -l from -d "Start date for aggregate"
+complete -f -c watson -n '__fish_watson_has_from aggregate' -s t -l to -d "end date for aggregate"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s p -l project -d "restrict to project" -a "(__fish_watson_get_projects)"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s T -l tag -d "restrict to tag" -a "(__fish_watson_get_tags)"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s j -l json -d "output json"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s g -l pager -d "view through pager"
+complete -f -c watson -n '__fish_watson_using_command aggregate' -s G -l no-pager -d "don't vew through pager"
+
 # config
 complete -f -c watson -n '__fish_watson_needs_sub' -a config -d "Get and set configuration options"
 complete -f -c watson -n '__fish_watson_using_command config' -s e -l edit -d "Edit the config with an editor"

--- a/watson.fish
+++ b/watson.fish
@@ -89,6 +89,11 @@ complete -f -c watson -n '__fish_watson_needs_sub' -a projects -d "Display the l
 complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list of tags"
 complete -f -c watson -n '__fish_watson_needs_sub' -a sync -d "sync your work with $url"
 
+# add
+complete -f -c watson -n '__fish_watson_needs_sub' -a add -d "Add time for project with tag(s) that was not tracked live."
+complete -f -c watson -n '__fish_watson_using_command add' -s f -l from -d "Start date for add"
+complete -f -c watson -n '__fish_watson_has_from add' -s t -l to -d "end date for add"
+
 # aggregate
 complete -f -c watson -n '__fish_watson_needs_sub' -a aggregate -d "Display a report of the time spent on each project aggregated by day."
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s c -l current -d "include the running frame"

--- a/watson.fish
+++ b/watson.fish
@@ -82,20 +82,20 @@ end
 
 # ungrouped
 complete -f -c watson -n '__fish_watson_needs_sub' -a cancel -d "Cancel the last start command"
-complete -f -c watson -n '__fish_watson_needs_sub' -a stop -d " Stop monitoring time for the current project"
 complete -f -c watson -n '__fish_watson_needs_sub' -a frames -d "Display the list of all frame IDs"
 complete -f -c watson -n '__fish_watson_needs_sub' -a help -d "Display help information"
 complete -f -c watson -n '__fish_watson_needs_sub' -a projects -d "Display the list of projects"
-complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list of tags"
+complete -f -c watson -n '__fish_watson_needs_sub' -a stop -d " Stop monitoring time for the current project"
 complete -f -c watson -n '__fish_watson_needs_sub' -a sync -d "sync your work with $url"
+complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list of tags"
 
 # add
-complete -f -c watson -n '__fish_watson_needs_sub' -a add -d "Add time for project with tag(s) that was not tracked live."
+complete -f -c watson -n '__fish_watson_needs_sub' -a add -d "Add time for project with tag(s) that was not tracked live"
 complete -f -c watson -n '__fish_watson_using_command add' -s f -l from -d "Start date for add"
 complete -f -c watson -n '__fish_watson_has_from add' -s t -l to -d "end date for add"
 
 # aggregate
-complete -f -c watson -n '__fish_watson_needs_sub' -a aggregate -d "Display a report of the time spent on each project aggregated by day."
+complete -f -c watson -n '__fish_watson_needs_sub' -a aggregate -d "Display a report of the time spent on each project aggregated by day"
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s c -l current -d "include the running frame"
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s C -l no-current -d "exclude the running frame (default)"
 complete -f -c watson -n '__fish_watson_using_command aggregate' -s f -l from -d "Start date for aggregate"
@@ -161,6 +161,7 @@ complete -f -c watson -n '__fish_watson_using_command report' -s j -l json -d "o
 complete -f -c watson -n '__fish_watson_using_command report' -s g -l pager -d "view through pager"
 complete -f -c watson -n '__fish_watson_using_command report' -s G -l no-pager -d "don't vew through pager"
 
+# restart
 complete -f -c watson -n '__fish_watson_needs_sub' -a restart -d "Restart monitoring time for a stopped project"
 complete -f -c watson -n '__fish_watson_using_command restart' -s s -l stop -d "stop running project"
 complete -f -c watson -n '__fish_watson_using_command restart' -s S -l no-stop -d "do not stop running project"

--- a/watson.fish
+++ b/watson.fish
@@ -85,7 +85,6 @@ complete -f -c watson -n '__fish_watson_needs_sub' -a cancel -d "Cancel the last
 complete -f -c watson -n '__fish_watson_needs_sub' -a frames -d "Display the list of all frame IDs"
 complete -f -c watson -n '__fish_watson_needs_sub' -a help -d "Display help information"
 complete -f -c watson -n '__fish_watson_needs_sub' -a projects -d "Display the list of projects"
-complete -f -c watson -n '__fish_watson_needs_sub' -a stop -d " Stop monitoring time for the current project"
 complete -f -c watson -n '__fish_watson_needs_sub' -a sync -d "sync your work with $url"
 complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list of tags"
 
@@ -93,6 +92,8 @@ complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list 
 complete -f -c watson -n '__fish_watson_needs_sub' -a add -d "Add time for project with tag(s) that was not tracked live"
 complete -f -c watson -n '__fish_watson_using_command add' -s f -l from -d "Start date for add"
 complete -f -c watson -n '__fish_watson_has_from add' -s t -l to -d "end date for add"
+complete -f -c watson -n '__fish_watson_has_from add' -s c -l confirm-new-project -d "Confirm addition of new project"
+complete -f -c watson -n '__fish_watson_has_from add' -s b -l confirm-new-tag -d "Confirm addition of new tag"
 
 # aggregate
 complete -f -c watson -n '__fish_watson_needs_sub' -a aggregate -d "Display a report of the time spent on each project aggregated by day"
@@ -123,6 +124,7 @@ complete -f -c watson -n '__fish_watson_using_command log' -s f -l from -d "Star
 complete -f -c watson -n '__fish_watson_has_from log' -s t -l to -d "end date for log"
 complete -f -c watson -n '__fish_watson_using_command log' -s y -l year -d "show the last year"
 complete -f -c watson -n '__fish_watson_using_command log' -s m -l month -d "show the last month"
+complete -f -c watson -n '__fish_watson_using_command log' -s l -l luna -d "show the last lunar cycle"
 complete -f -c watson -n '__fish_watson_using_command log' -s w -l week -d "show week-to-day"
 complete -f -c watson -n '__fish_watson_using_command log' -s d -l day -d "show today"
 complete -f -c watson -n '__fish_watson_using_command log' -s a -l all -d "show all"
@@ -154,6 +156,7 @@ complete -f -c watson -n '__fish_watson_using_command report' -s f -l from -d "S
 complete -f -c watson -n '__fish_watson_has_from report' -s t -l to -d "end date for report"
 complete -f -c watson -n '__fish_watson_using_command report' -s y -l year -d "show the last year"
 complete -f -c watson -n '__fish_watson_using_command report' -s m -l month -d "show the last month"
+complete -f -c watson -n '__fish_watson_using_command report' -s l -l luna -d "show the last lunar cycle"
 complete -f -c watson -n '__fish_watson_using_command report' -s w -l week -d "show week-to-day"
 complete -f -c watson -n '__fish_watson_using_command report' -s d -l day -d "show today"
 complete -f -c watson -n '__fish_watson_using_command report' -s a -l all -d "show all"
@@ -180,3 +183,7 @@ complete -f -c watson -n '__fish_watson_needs_sub' -a status -d "Display when th
 complete -f -c watson -n '__fish_watson_using_command status' -s p -l project -d "only show project"
 complete -f -c watson -n '__fish_watson_using_command status' -s t -l tags -d "only show tags"
 complete -f -c watson -n '__fish_watson_using_command status' -s e -l elapsed -d "only show elapsed time"
+
+# stop
+complete -f -c watson -n '__fish_watson_needs_sub' -a stop -d "Stop monitoring time for the current project"
+complete -f -c watson -n '__fish_watson_using_command stop' -l at -d "Stop frame at this time (YYYY-MM-DDT)?HH:MM(:SS)?"

--- a/watson.fish
+++ b/watson.fish
@@ -92,8 +92,8 @@ complete -f -c watson -n '__fish_watson_needs_sub' -a tags -d "Display the list 
 complete -f -c watson -n '__fish_watson_needs_sub' -a add -d "Add time for project with tag(s) that was not tracked live"
 complete -f -c watson -n '__fish_watson_using_command add' -s f -l from -d "Start date for add"
 complete -f -c watson -n '__fish_watson_has_from add' -s t -l to -d "end date for add"
-complete -f -c watson -n '__fish_watson_has_from add' -s c -l confirm-new-project -d "Confirm addition of new project"
-complete -f -c watson -n '__fish_watson_has_from add' -s b -l confirm-new-tag -d "Confirm addition of new tag"
+complete -f -c watson -n '__fish_watson_using_command add' -s c -l confirm-new-project -d "Confirm addition of new project"
+complete -f -c watson -n '__fish_watson_using_command add' -s b -l confirm-new-tag -d "Confirm addition of new tag"
 
 # aggregate
 complete -f -c watson -n '__fish_watson_needs_sub' -a aggregate -d "Display a report of the time spent on each project aggregated by day"


### PR DESCRIPTION
Update the fish completions profile to support newly added commands.
Some unseen work was also done: notably organizing the ungrouped commands.
Adds support for new features:
- limit to lunar cycles
- support csv output

# Completions Added
- add
- aggregate (fixes #289 )

# Completions Extended
- report
- log
- stop (#233)

# Tests Ran:
- tests were ran against the current master position: 30313be
- Due to the nature of completion profiles, proof of testing can be tricky, I encourage another fish user to vet these additions as well.
## add
```
chimera  ~/  watson add --from 2019-07-04-00:00 --to 2019-07-04-23:00 "take the day off"
Adding project take the day off, started 4 days ago and stopped 4 days ago. (id: c9874b9)

chimera  ~/  watson add --from 2019-07-04-00:00 --to 2019-07-04-23:00 "take the day off" +test
Adding project take the day off [test], started 4 days ago and stopped 4 days ago. (id: b163455)

chimera  ~/  watson add --from 2019-07-04-00:00 --to 2019-07-04-23:00 "take the day off" +test2 --confirm-new-tag 
Tag 'test2' does not exist yet. Create it? [y/N]: y
Adding project take the day off [test2], started 4 days ago and stopped 4 days ago. (id: 7411689)

chimera  ~/  watson remove 7411689
You are about to remove frame take the day off [test2] from 00:00 to 00:00, continue? [y/N]: y
Frame removed

chimera  ~/  watson remove b163455
You are about to remove frame take the day off [test] from 00:00 to 00:00, continue? [y/N]: y
Frame removed.
```
- we see here that I didn't understand how to properly enter my time, this may need to be clarified in the docs, not unlike `watson stop --at`.  That is out of scope for this particular PR though.
## aggregate
```
chimera  ~/  watson aggregate --project "take the day off" -G
Mon 01 July 2019 - 00s


Tue 02 July 2019 - 00s


Wed 03 July 2019 - 00s


Thu 04 July 2019 - 00s
  take the day off - 00s


Fri 05 July 2019 - 00s


Sat 06 July 2019 - 00s


Sun 07 July 2019 - 00s


Mon 08 July 2019 - 00s
```
## csv support
```
chimera  ~/  watson aggregate --csv       Mon 08 Jul 2019 04:24:40 PM CDT
project,to,tag,from,time
take the day off,2019-07-04 23:59:59,,2019-07-04 00:00:00,0.0
```
## lunar support
```
chimera  ~/  watson log --luna -G
Thursday 04 July 2019 (00s)
  c9874b9  00:00 to 00:00          00s  take the day off
```
