### PR TITLE
Fix fatal AttributeError using Arrow 0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update zsh shell completion (#264).
+- Fix fatal AttributeError using Arrow 0.14.5 (#300)
 
 ### Removed
 

--- a/scripts/fuzzer.py
+++ b/scripts/fuzzer.py
@@ -27,23 +27,22 @@ projects = [
 
 now = arrow.now()
 
-for date in arrow.Arrow.range('day', now.replace(months=-1), now):
+for date in arrow.Arrow.range('day', now.shift(months=-1), now):
     if date.weekday() in (5, 6):
         # Weekend \o/
         continue
 
-    start = date.replace(
-        hour=9, minute=random.randint(0, 59), seconds=random.randint(0, 59)
-    )
+    start = date.replace(hour=9, minute=random.randint(0, 59)) \
+                .shift(seconds=random.randint(0, 59))
 
     while start.hour < random.randint(16, 19):
         project, tags = random.choice(projects)
         frame = watson.frames.add(
             project,
             start,
-            start.replace(seconds=random.randint(60, 4 * 60 * 60)),
+            start.shift(seconds=random.randint(60, 4 * 60 * 60)),
             tags=random.sample(tags, random.randint(0, len(tags)))
         )
-        start = frame.stop.replace(seconds=random.randint(0, 1 * 60 * 60))
+        start = frame.stop.shift(seconds=random.randint(0, 1 * 60 * 60))
 
 watson.save()

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -405,7 +405,7 @@ _SHORTCUT_OPTIONS_VALUES = {
 @click.option('-c/-C', '--current/--no-current', 'current', default=None,
               help="(Don't) include currently running frame in report.")
 @click.option('-f', '--from', 'from_', cls=MutuallyExclusiveOption, type=Date,
-              default=arrow.now().replace(days=-7),
+              default=arrow.now().shift(days=-7),
               mutually_exclusive=_SHORTCUT_OPTIONS,
               help="The date from when the report should start. Defaults "
               "to seven days ago.")
@@ -694,7 +694,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
 @click.option('-c/-C', '--current/--no-current', 'current', default=None,
               help="(Don't) include currently running frame in report.")
 @click.option('-f', '--from', 'from_', cls=MutuallyExclusiveOption, type=Date,
-              default=arrow.now().replace(days=-7),
+              default=arrow.now().shift(days=-7),
               mutually_exclusive=_SHORTCUT_OPTIONS,
               help="The date from when the report should start. Defaults "
               "to seven days ago.")
@@ -835,7 +835,7 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
 @click.option('-c/-C', '--current/--no-current', 'current', default=None,
               help="(Don't) include currently running frame in output.")
 @click.option('-f', '--from', 'from_', type=Date,
-              default=arrow.now().replace(days=-7),
+              default=arrow.now().shift(days=-7),
               help="The date from when the log should start. Defaults "
               "to seven days ago.")
 @click.option('-t', '--to', type=Date, default=arrow.now(),

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -174,7 +174,7 @@ def get_start_time_for_period(period):
     if period == 'day':
         start_time = arrow.Arrow(year, month, day)
     elif period == 'week':
-        start_time = arrow.Arrow.fromdate(now.replace(days=-weekday).date())
+        start_time = arrow.Arrow.fromdate(now.shift(days=-weekday).date())
     elif period == 'month':
         start_time = arrow.Arrow(year, month, 1)
     elif period == 'luna':
@@ -204,7 +204,7 @@ def apply_weekday_offset(start_time, week_start):
         return start_time
     now = datetime.datetime.now()
     offset = weekdays[new_start] - 7 * (weekdays[new_start] > now.weekday())
-    return start_time.replace(days=offset)
+    return start_time.shift(days=offset)
 
 
 def make_json_writer(func, *args, **kwargs):


### PR DESCRIPTION
Since [Arrow 0.14.5](https://github.com/crsmithdev/arrow/blob/master/HISTORY.md#0145), `Arrow.replace()` has dropped shift functionality in favor of `Arrow.shift()`. The changelog states:

> [CHANGE] Removed deprecated replace shift functionality. Users looking to pass plural properties to the replace function to shift values should use shift instead.

This causes an `AttributeError` exception every time watson is run.

The error message is: 

> AttributeError: unknown attribute: "days"'

It can be reproduced just upgrading your Arrow package in your watson venv:

	(.venv) $ pip install -U 

There are separate replace & shift functions since [Arrow 0.9.0](https://github.com/crsmithdev/arrow/blob/master/HISTORY.md#090) and shifting using replace was [marked deprecated since 0.7.1](https://github.com/crsmithdev/arrow/commit/d7120026a297dc8300d18675aa2070e288930057)