### PR TITLE
Fixes #280 (doc generation with Python 3.7)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ copyright: >
   Watson, by <a
   href="http://tailordev.fr?pk_campaign=watson&amp;pk_kwd=docs">TailorDev</a>
   &amp; al. is released under the MIT License.
-pages:
+nav:
 - Home: 'index.md'
 - User Guide:
     - Commands: 'user-guide/commands.md'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
 
 # Docs
-mkdocs<0.15.0
+mkdocs
+mkdocs-bootswatch
 
 # Release
 wheel


### PR DESCRIPTION
Fixes #280 and update `mkdocs.yml` [(pages &rarr; nav)](https://www.mkdocs.org/about/release-notes/#version-10-2018-08-03)