### PR TITLE
Remove `python2.7` from supported versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=flake8
-        - python: 2.7
-          os: linux
-          dist: trusty
-          env: TOXENV=py27
         - python: 3.5
           os: linux
           dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `log` command output can now be filtered to exclude projects and tags via `--ignore-project` and `--ignore-tag` (#395)
 
+### Removed
+
+- Python 2.7 support (#305).
+
 ## [1.10.0] - 2020-07-03
 
 ### Added

--- a/scripts/fuzzer.py
+++ b/scripts/fuzzer.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import arrow
 import random

--- a/scripts/gen-cli-docs.py
+++ b/scripts/gen-cli-docs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import inspect
 

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     license='MIT',
     long_description=readme,
     install_requires=parse_requirements('requirements.txt'),
+    python_requires='>=3.5',
     tests_require=parse_requirements('requirements-dev.txt'),
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Setup file for the Watson distribution."""
 
 from os.path import join

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,16 +2,8 @@
 
 import os
 import datetime
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+import mock
+from io import StringIO
 
 import py
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ from . import mock_read
 
 
 def test_config_get(mocker, watson):
-    content = u"""
+    content = """
 [backend]
 url = foo
 token =
@@ -24,7 +24,7 @@ token =
 
 
 def test_config_getboolean(mocker, watson):
-    content = u"""
+    content = """
 [options]
 flag1 = 1
 flag2 = ON
@@ -48,7 +48,7 @@ flag6 =
 
 
 def test_config_getint(mocker, watson):
-    content = u"""
+    content = """
 [options]
 value1 = 42
 value2 = spamm
@@ -72,7 +72,7 @@ value3 =
 
 
 def test_config_getfloat(mocker, watson):
-    content = u"""
+    content = """
 [options]
 value1 = 3.14
 value2 = 42
@@ -99,7 +99,7 @@ value4 =
 
 
 def test_config_getlist(mocker, watson):
-    content = u"""
+    content = """
 # empty lines in option values (including the first one) are discarded
 [options]
 value1 =

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,7 +35,6 @@ from watson.utils import (
     safe_save,
     sorted_groupby,
     parse_tags,
-    PY2,
     json_arrow_encoder,
 )
 from . import mock_datetime
@@ -107,8 +106,6 @@ def test_make_json_writer_with_unicode():
     writer = make_json_writer(lambda: {u'ùñï©ôð€': u'εvεrywhεrε'})
     writer(fp)
     expected = u'{\n "ùñï©ôð€": "εvεrywhεrε"\n}'
-    if PY2:
-        expected = expected.encode('utf-8')
     assert fp.getvalue() == expected
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Unit tests for the 'utils' module."""
 
 import arrow

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,9 +95,9 @@ def test_make_json_writer_with_kwargs():
 
 def test_make_json_writer_with_unicode():
     fp = StringIO()
-    writer = make_json_writer(lambda: {u'ùñï©ôð€': u'εvεrywhεrε'})
+    writer = make_json_writer(lambda: {'ùñï©ôð€': 'εvεrywhεrε'})
     writer(fp)
-    expected = u'{\n "ùñï©ôð€": "εvεrywhεrε"\n}'
+    expected = '{\n "ùñï©ôð€": "εvεrywhεrε"\n}'
     assert fp.getvalue() == expected
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,15 +9,8 @@ import json
 import os
 import datetime
 import operator
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from io import StringIO
+from mock import patch
 import pytest
 from click.exceptions import Abort
 from dateutil.tz import tzutc

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -199,7 +199,7 @@ toto
 
 
 def test_empty_config(mocker, watson):
-    mocker.patch.object(ConfigParser, 'read', mock_read(u''))
+    mocker.patch.object(ConfigParser, 'read', mock_read(''))
     assert len(watson.config.sections()) == 0
 
 

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -10,15 +10,11 @@ import requests
 
 from watson import Watson, WatsonError
 from watson.watson import ConfigParser, ConfigurationError
-from watson.utils import PY2
 
 from . import mock_read, TEST_FIXTURE_DIR
 
 
-if not PY2:
-    builtins = 'builtins'
-else:
-    builtins = '__builtin__'
+builtins = 'builtins'
 
 
 @pytest.fixture

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -190,7 +190,7 @@ def test_empty_config_dir():
 
 
 def test_wrong_config(mocker, watson):
-    content = u"""
+    content = """
 toto
     """
     mocker.patch.object(ConfigParser, 'read', mock_read(content))
@@ -237,7 +237,7 @@ def test_start_two_projects(watson):
 
 
 def test_start_default_tags(mocker, watson):
-    content = u"""
+    content = """
 [default_tags]
 my project = A B
     """
@@ -248,7 +248,7 @@ my project = A B
 
 
 def test_start_default_tags_with_supplementary_input_tags(mocker, watson):
-    content = u"""
+    content = """
 [default_tags]
 my project = A B
     """

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -14,9 +14,6 @@ from watson.watson import ConfigParser, ConfigurationError
 from . import mock_read, TEST_FIXTURE_DIR
 
 
-builtins = 'builtins'
-
-
 @pytest.fixture
 def json_mock(mocker):
     return mocker.patch.object(
@@ -32,27 +29,27 @@ def json_mock(mocker):
 def test_current(mocker, watson):
     content = json.dumps({'project': 'foo', 'start': 4000, 'tags': ['A', 'B']})
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert watson.current['project'] == 'foo'
     assert watson.current['start'] == arrow.get(4000)
     assert watson.current['tags'] == ['A', 'B']
 
 
 def test_current_with_empty_file(mocker, watson):
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=""))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=""))
     mocker.patch('os.path.getsize', return_value=0)
     assert watson.current == {}
 
 
 def test_current_with_nonexistent_file(mocker, watson):
-    mocker.patch('%s.open' % builtins, side_effect=IOError)
+    mocker.patch('builtins.open', side_effect=IOError)
     assert watson.current == {}
 
 
 def test_current_watson_non_valid_json(mocker, watson):
     content = "{'foo': bar}"
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     mocker.patch('os.path.getsize', return_value=len(content))
     with pytest.raises(WatsonError):
         watson.current
@@ -63,7 +60,7 @@ def test_current_with_given_state(config_dir, mocker):
     watson = Watson(current={'project': 'bar', 'start': 4000},
                     config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert watson.current['project'] == 'bar'
 
 
@@ -71,7 +68,7 @@ def test_current_with_empty_given_state(config_dir, mocker):
     content = json.dumps({'project': 'foo', 'start': 4000})
     watson = Watson(current=[], config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert watson.current == {}
 
 
@@ -81,25 +78,25 @@ def test_last_sync(mocker, watson):
     now = arrow.get(4123)
     content = json.dumps(now.timestamp)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert watson.last_sync == now
 
 
 def test_last_sync_with_empty_file(mocker, watson):
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=""))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=""))
     mocker.patch('os.path.getsize', return_value=0)
     assert watson.last_sync == arrow.get(0)
 
 
 def test_last_sync_with_nonexistent_file(mocker, watson):
-    mocker.patch('%s.open' % builtins, side_effect=IOError)
+    mocker.patch('builtins.open', side_effect=IOError)
     assert watson.last_sync == arrow.get(0)
 
 
 def test_last_sync_watson_non_valid_json(mocker, watson):
     content = "{'foo': bar}"
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     mocker.patch('os.path.getsize', return_value=len(content))
     with pytest.raises(WatsonError):
         watson.last_sync
@@ -110,7 +107,7 @@ def test_last_sync_with_given_state(config_dir, mocker):
     now = arrow.now()
     watson = Watson(last_sync=now, config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert watson.last_sync == now
 
 
@@ -118,7 +115,7 @@ def test_last_sync_with_empty_given_state(config_dir, mocker):
     content = json.dumps(123)
     watson = Watson(last_sync=None, config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert watson.last_sync == arrow.get(0)
 
 
@@ -127,7 +124,7 @@ def test_last_sync_with_empty_given_state(config_dir, mocker):
 def test_frames(mocker, watson):
     content = json.dumps([[4000, 4010, 'foo', None, ['A', 'B', 'C']]])
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert len(watson.frames) == 1
     assert watson.frames[0].project == 'foo'
     assert watson.frames[0].start == arrow.get(4000)
@@ -138,7 +135,7 @@ def test_frames(mocker, watson):
 def test_frames_without_tags(mocker, watson):
     content = json.dumps([[4000, 4010, 'foo', None]])
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert len(watson.frames) == 1
     assert watson.frames[0].project == 'foo'
     assert watson.frames[0].start == arrow.get(4000)
@@ -147,20 +144,20 @@ def test_frames_without_tags(mocker, watson):
 
 
 def test_frames_with_empty_file(mocker, watson):
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=""))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=""))
     mocker.patch('os.path.getsize', return_value=0)
     assert len(watson.frames) == 0
 
 
 def test_frames_with_nonexistent_file(mocker, watson):
-    mocker.patch('%s.open' % builtins, side_effect=IOError)
+    mocker.patch('builtins.open', side_effect=IOError)
     assert len(watson.frames) == 0
 
 
 def test_frames_watson_non_valid_json(mocker, watson):
     content = "{'foo': bar}"
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     mocker.patch('os.path.getsize', return_value=len(content))
     with pytest.raises(WatsonError):
         watson.frames
@@ -171,7 +168,7 @@ def test_given_frames(config_dir, mocker):
     watson = Watson(frames=[[4000, 4010, 'bar', None, ['A', 'B']]],
                     config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert len(watson.frames) == 1
     assert watson.frames[0].project == 'bar'
     assert watson.frames[0].tags == ['A', 'B']
@@ -181,7 +178,7 @@ def test_frames_with_empty_given_state(config_dir, mocker):
     content = json.dumps([[0, 10, 'foo', None, ['A']]])
     watson = Watson(frames=[], config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert len(watson.frames) == 0
 
 
@@ -361,7 +358,7 @@ def test_cancel_no_project(watson):
 # save
 
 def test_save_without_changes(mocker, watson, json_mock):
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert not json_mock.called
@@ -370,7 +367,7 @@ def test_save_without_changes(mocker, watson, json_mock):
 def test_save_current(mocker, watson, json_mock):
     watson.start('foo', ['A', 'B'])
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert json_mock.call_count == 1
@@ -383,7 +380,7 @@ def test_save_current(mocker, watson, json_mock):
 def test_save_current_without_tags(mocker, watson, json_mock):
     watson.start('foo')
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert json_mock.call_count == 1
@@ -399,7 +396,7 @@ def test_save_current_without_tags(mocker, watson, json_mock):
 def test_save_empty_current(config_dir, mocker, json_mock):
     watson = Watson(current={}, config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
 
     watson.current = {'project': 'foo', 'start': 4000}
     watson.save()
@@ -420,7 +417,7 @@ def test_save_frames_no_change(config_dir, mocker, json_mock):
     watson = Watson(frames=[[4000, 4010, 'foo', None]],
                     config_dir=config_dir)
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert not json_mock.called
@@ -430,7 +427,7 @@ def test_save_added_frame(config_dir, mocker, json_mock):
     watson = Watson(frames=[[4000, 4010, 'foo', None]], config_dir=config_dir)
     watson.frames.add('bar', 4010, 4020, ['A'])
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert json_mock.call_count == 1
@@ -447,7 +444,7 @@ def test_save_changed_frame(config_dir, mocker, json_mock):
                     config_dir=config_dir)
     watson.frames[0] = ('bar', 4000, 4010, ['A', 'B'])
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert json_mock.call_count == 1
@@ -461,7 +458,7 @@ def test_save_changed_frame(config_dir, mocker, json_mock):
 
 
 def test_save_config_no_changes(mocker, watson):
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     write_mock = mocker.patch.object(ConfigParser, 'write')
     watson.save()
 
@@ -469,7 +466,7 @@ def test_save_config_no_changes(mocker, watson):
 
 
 def test_save_config(mocker, watson):
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     write_mock = mocker.patch.object(ConfigParser, 'write')
     watson.config = ConfigParser()
     watson.save()
@@ -481,7 +478,7 @@ def test_save_last_sync(mocker, watson, json_mock):
     now = arrow.now()
     watson.last_sync = now
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert json_mock.call_count == 1
@@ -492,7 +489,7 @@ def test_save_empty_last_sync(config_dir, mocker, json_mock):
     watson = Watson(last_sync=arrow.now(), config_dir=config_dir)
     watson.last_sync = None
 
-    mocker.patch('%s.open' % builtins, mocker.mock_open())
+    mocker.patch('builtins.open', mocker.mock_open())
     watson.save()
 
     assert json_mock.call_count == 1
@@ -862,7 +859,7 @@ def test_report_include_partial_frames(mocker, watson, date_as_unixtime,
         ["cli"],
         1548797432
     ]])
-    mocker.patch('%s.open' % builtins, mocker.mock_open(read_data=content))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     date = arrow.get(date_as_unixtime)
     report = watson.report(
         from_=date, to=date, include_partial_frames=include_partial,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py35,py36,py37
+envlist = flake8,py35,py36,py37
 skip_missing_interpreters = True
 
 [testenv]

--- a/watson/__main__.py
+++ b/watson/__main__.py
@@ -1,6 +1,3 @@
-try:
-    from watson import cli
-except ImportError:
-    from . import cli
+from watson import cli
 
 cli.cli()

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -159,7 +159,7 @@ def help(ctx, command):
     cmd = cli.get_command(ctx, command)
 
     if not cmd:
-        raise click.ClickException(u"No such command: {}".format(command))
+        raise click.ClickException("No such command: {}".format(command))
 
     click.echo(cmd.get_help(ctx))
 
@@ -170,7 +170,7 @@ def _start(watson, project, tags, restart=False, start_at=None, gap=True):
     """
     current = watson.start(project, tags, restart=restart, start_at=start_at,
                            gap=gap,)
-    click.echo(u"Starting project {}{} at {}".format(
+    click.echo("Starting project {}{} at {}".format(
         style('project', project),
         (" " if current['tags'] else "") + style('tags', current['tags']),
         style('time', "{:HH:mm}".format(current['start']))
@@ -283,7 +283,7 @@ def stop(watson, at_):
     Stopping project apollo11, started an hour ago and stopped 30 minutes ago. (id: e9ccd52) # noqa: E501
     """
     frame = watson.stop(stop_at=at_)
-    output_str = u"Stopping project {}{}, started {} and stopped {}. (id: {})"
+    output_str = "Stopping project {}{}, started {} and stopped {}. (id: {})"
     click.echo(output_str.format(
         style('project', frame.project),
         (" " if frame.tags else "") + style('tags', frame.tags),
@@ -345,7 +345,7 @@ def restart(ctx, watson, frame, stop_, at_):
         else:
             # Raise error here, instead of in watson.start(), otherwise
             # will give misleading error if running frame is the first one
-            raise click.ClickException(u"{} {} {}".format(
+            raise click.ClickException("{} {} {}".format(
                 style('error', "Project already started:"),
                 style('project', watson.current['project']),
                 style('tags', watson.current['tags'])))
@@ -364,7 +364,7 @@ def cancel(watson):
     not be recorded.
     """
     old = watson.cancel()
-    click.echo(u"Canceling the timer for project {}{}".format(
+    click.echo("Canceling the timer for project {}{}".format(
         style('project', old['project']),
         (" " if old['tags'] else "") + style('tags', old['tags'])
     ))
@@ -407,26 +407,26 @@ def status(watson, project, tags, elapsed):
     current = watson.current
 
     if project:
-        click.echo(u"{}".format(
+        click.echo("{}".format(
             style('project', current['project']),
         ))
         return
 
     if tags:
-        click.echo(u"{}".format(
+        click.echo("{}".format(
             style('tags', current['tags'])
         ))
         return
 
     if elapsed:
-        click.echo(u"{}".format(
+        click.echo("{}".format(
             style('time', current['start'].humanize())
         ))
         return
 
     datefmt = watson.config.get('options', 'date_format', '%Y.%m.%d')
     timefmt = watson.config.get('options', 'time_format', '%H:%M:%S%z')
-    click.echo(u"Project {}{} started {} ({} {})".format(
+    click.echo("Project {}{} started {} ({} {})".format(
         style('project', current['project']),
         (" " if current['tags'] else "") + style('tags', current['tags']),
         style('time', current['start'].humanize()),
@@ -1091,7 +1091,7 @@ def log(watson, current, reverse, from_, to, projects, tags, ignore_projects,
         )
 
         _print("\n".join(
-            u"\t{id}  {start} to {stop}  {delta:>11}  {project}{tags}".format(
+            "\t{id}  {start} to {stop}  {delta:>11}  {project}{tags}".format(
                 delta=format_timedelta(frame.stop - frame.start),
                 project=style('project', '{:>{}}'.format(
                     frame.project, longest_project
@@ -1221,7 +1221,7 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
     # add a new frame, call watson save to update state files
     frame = watson.add(project=project, tags=tags, from_date=from_, to_date=to)
     click.echo(
-        u"Adding project {}{}, started {} and stopped {}. (id: {})".format(
+        "Adding project {}{}, started {} and stopped {}. (id: {})".format(
             style('project', frame.project),
             (" " if frame.tags else "") + style('tags', frame.tags),
             style('time', frame.start.humanize()),
@@ -1326,7 +1326,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
             #  the edit function normally
             break
         except (ValueError, TypeError, RuntimeError) as e:
-            click.echo(u"Error while parsing inputted values: {}".format(e),
+            click.echo("Error while parsing inputted values: {}".format(e),
                        err=True)
         except KeyError:
             click.echo(
@@ -1348,8 +1348,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
 
     watson.save()
     click.echo(
-        u"Edited frame for project {project}{tags}, from {start} to {stop} "
-        u"({delta})".format(
+        "Edited frame for project {project}{tags}, from {start} to {stop} "
+        "({delta})".format(
             delta=format_timedelta(stop - start) if stop else '-',
             project=style('project', project),
             tags=(" " if tags else "") + style('tags', tags),
@@ -1381,8 +1381,8 @@ def remove(watson, id, force):
 
     if not force:
         click.confirm(
-            u"You are about to remove frame "
-            u"{project}{tags} from {start} to {stop}, continue?".format(
+            "You are about to remove frame "
+            "{project}{tags} from {start} to {stop}, continue?".format(
                 project=style('project', frame.project),
                 tags=(" " if frame.tags else "") + style('tags', frame.tags),
                 start=style('time', '{:HH:mm}'.format(frame.start)),
@@ -1457,11 +1457,11 @@ def config(context, key, value, edit):
 
     if value is None:
         if not wconfig.has_section(section):
-            raise click.ClickException(u"No such section {}".format(section))
+            raise click.ClickException("No such section {}".format(section))
 
         if not wconfig.has_option(section, option):
             raise click.ClickException(
-                u"No such option {} in {}".format(option, section)
+                "No such option {} in {}".format(option, section)
             )
 
         click.echo(wconfig.get(section, option))
@@ -1606,7 +1606,7 @@ def merge(watson, frames_with_conflict, force):
             'tags': original_frame.tags
         }
         click.echo("frame {}:".format(style('short_id', original_frame.id)))
-        click.echo(u"{}".format('\n'.join('<' + line for line in json.dumps(
+        click.echo("{}".format('\n'.join('<' + line for line in json.dumps(
             original_frame_data, indent=4, ensure_ascii=False).splitlines())))
         click.echo("---")
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -651,7 +651,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
             lines.append(line)
 
         def _final_print(lines):
-            click.echo_via_pager(u'\n'.join(lines))
+            click.echo_via_pager('\n'.join(lines))
     elif aggregated:
 
         def _print(line):
@@ -669,7 +669,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
 
     # handle special title formatting for aggregate reports
     if aggregated:
-        _print(u'{} - {}'.format(
+        _print('{} - {}'.format(
             style('date', '{:ddd DD MMMM YYYY}'.format(
                 report['timespan']['from']
             )),
@@ -679,7 +679,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
         ))
 
     else:
-        _print(u'{} -> {}\n'.format(
+        _print('{} -> {}\n'.format(
             style('date', '{:ddd DD MMMM YYYY}'.format(
                 report['timespan']['from']
             )),
@@ -691,7 +691,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
     projects = report['projects']
 
     for project in projects:
-        _print(u'{tab}{project} - {time}'.format(
+        _print('{tab}{project} - {time}'.format(
             tab=tab,
             time=style('time', format_timedelta(
                 datetime.timedelta(seconds=project['time'])
@@ -704,11 +704,11 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
             longest_tag = max(len(tag) for tag in tags or [''])
 
             for tag in tags:
-                _print(u'\t[{tag} {time}]'.format(
+                _print('\t[{tag} {time}]'.format(
                     time=style('time', '{:>11}'.format(format_timedelta(
                         datetime.timedelta(seconds=tag['time'])
                     ))),
-                    tag=style('tag', u'{:<{}}'.format(
+                    tag=style('tag', '{:<{}}'.format(
                         tag['name'], longest_tag
                     )),
                 ))
@@ -859,7 +859,7 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
             if (len(output)) == 1:
                 output[0] += '\n'
 
-            lines.append(u'\n'.join(output))
+            lines.append('\n'.join(output))
 
     if 'json' in output_format:
         click.echo(json.dumps(lines, indent=4, sort_keys=True,
@@ -868,9 +868,9 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
         click.echo(build_csv(lines))
     elif pager or (pager is None and
                    watson.config.getboolean('options', 'pager', True)):
-        click.echo_via_pager(u'\n\n'.join(lines))
+        click.echo_via_pager('\n\n'.join(lines))
     else:
-        click.echo(u'\n\n'.join(lines))
+        click.echo('\n\n'.join(lines))
 
 
 @cli.command()
@@ -1093,7 +1093,7 @@ def log(watson, current, reverse, from_, to, projects, tags, ignore_projects,
         _print("\n".join(
             u"\t{id}  {start} to {stop}  {delta:>11}  {project}{tags}".format(
                 delta=format_timedelta(frame.stop - frame.start),
-                project=style('project', u'{:>{}}'.format(
+                project=style('project', '{:>{}}'.format(
                     frame.project, longest_project
                 )),
                 tags=(" "*2 if frame.tags else "") + style('tags', frame.tags),
@@ -1680,19 +1680,19 @@ def rename(watson, rename_type, old_name, new_name):
     """
     if rename_type == 'tag':
         watson.rename_tag(old_name, new_name)
-        click.echo(u'Renamed tag "{}" to "{}"'.format(
+        click.echo('Renamed tag "{}" to "{}"'.format(
                         style('tag', old_name),
                         style('tag', new_name)
                    ))
     elif rename_type == 'project':
         watson.rename_project(old_name, new_name)
-        click.echo(u'Renamed project "{}" to "{}"'.format(
+        click.echo('Renamed project "{}" to "{}"'.format(
                         style('project', old_name),
                         style('project', new_name)
                    ))
     else:
         raise click.ClickException(style(
             'error',
-            u'You have to call rename with type "project" or "tag"; '
-            u'you supplied "%s"' % rename_type
+            'You have to call rename with type "project" or "tag"; '
+            'you supplied "%s"' % rename_type
         ))

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import datetime
 import itertools
 import json

--- a/watson/config.py
+++ b/watson/config.py
@@ -2,11 +2,7 @@
 """A convenience and compatibility wrapper for RawConfigParser."""
 
 import shlex
-
-try:
-    from configparser import RawConfigParser
-except ImportError:
-    from ConfigParser import RawConfigParser
+from configparser import RawConfigParser
 
 __all__ = ('ConfigParser',)
 

--- a/watson/config.py
+++ b/watson/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """A convenience and compatibility wrapper for RawConfigParser."""
 
 import shlex

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -22,7 +22,7 @@ class Frame(namedtuple('Frame', HEADERS)):
                 updated_at = arrow.get(updated_at)
         except (ValueError, TypeError) as e:
             from .watson import WatsonError
-            raise WatsonError(u"Error converting date: {}".format(e))
+            raise WatsonError("Error converting date: {}".format(e))
 
         start = start.to('local')
         stop = stop.to('local')
@@ -123,7 +123,7 @@ class Frames(object):
                 i for i, v in enumerate(self['id']) if v.startswith(id)
             )
         except StopIteration:
-            raise KeyError(u"Frame with id {} not found.".format(id))
+            raise KeyError("Frame with id {} not found.".format(id))
 
     def _get_col(self, col):
         index = HEADERS.index(col)

--- a/watson/fullmoon.py
+++ b/watson/fullmoon.py
@@ -226,7 +226,7 @@ def get_last_full_moon(d):
     idx = bisect.bisect_right(fullmoons, now)
     if idx in [0, len(fullmoons)]:
         raise ValueError(
-            u'watson has only full moon dates from year 2000 to 2099, not {}'
+            'watson has only full moon dates from year 2000 to 2099, not {}'
             .format(d.year))
 
     last = fullmoons[idx - 1]

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -7,12 +7,7 @@ import operator
 import os
 import shutil
 import tempfile
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
+from io import StringIO
 import click
 import arrow
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -141,7 +141,7 @@ def get_frame_from_argument(watson, arg):
             return watson.frames[index]
     except IndexError:
         raise click.ClickException(
-            style('error', u"No frame found for index {}.".format(arg))
+            style('error', "No frame found for index {}.".format(arg))
         )
     except (ValueError, TypeError):
         pass
@@ -150,8 +150,8 @@ def get_frame_from_argument(watson, arg):
     try:
         return watson.frames[arg]
     except KeyError:
-        raise click.ClickException(u"{} {}.".format(
-            style('error', u"No frame found with id"),
+        raise click.ClickException("{} {}.".format(
+            style('error', "No frame found with id"),
             style('short_id', arg))
         )
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -6,7 +6,6 @@ import json
 import operator
 import os
 import shutil
-import sys
 import tempfile
 
 try:
@@ -22,10 +21,6 @@ from .fullmoon import get_last_full_moon
 
 from click.exceptions import UsageError
 
-PY2 = sys.version_info[0] == 2
-
-if not PY2:
-    from builtins import TypeError, isinstance
 
 try:
     text_type = (str, unicode)
@@ -226,10 +221,6 @@ def make_json_writer(func, *args, **kwargs):
     """
     def writer(f):
         dump = json.dumps(func(*args, **kwargs), indent=1, ensure_ascii=False)
-        if PY2:
-            # in Python, json.dumps with ensure_ascii=False can return
-            # unicode, but we need to write bytes in the file
-            dump = dump.encode('utf-8')
         f.write(dump)
     return writer
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -17,12 +17,6 @@ from .fullmoon import get_last_full_moon
 from click.exceptions import UsageError
 
 
-try:
-    text_type = (str, unicode)
-except NameError:
-    text_type = str
-
-
 def create_watson():
     return _watson.Watson(config_dir=os.environ.get('WATSON_DIR'))
 
@@ -239,7 +233,7 @@ def safe_save(path, content, ext='.bak'):
     tmpfp = tempfile.NamedTemporaryFile(mode='w+', delete=False)
     try:
         with tmpfp:
-            if isinstance(content, text_type):
+            if isinstance(content, str):
                 tmpfp.write(content)
             else:
                 content(tmpfp)

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -53,7 +53,7 @@ def style(name, element):
         if not tags:
             return ''
 
-        return u'[{}]'.format(', '.join(
+        return '[{}]'.format(', '.join(
             style('tag', tag) for tag in tags
         ))
 
@@ -181,7 +181,7 @@ def get_start_time_for_period(period):
         # approximately timestamp `0`
         start_time = arrow.Arrow(1970, 1, 1)
     else:
-        raise ValueError(u'Unsupported period value: {}'.format(period))
+        raise ValueError('Unsupported period value: {}'.format(period))
 
     return start_time
 

--- a/watson/version.py
+++ b/watson/version.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 version = "1.10.0"

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -551,7 +551,7 @@ class Watson(object):
     def rename_project(self, old_project, new_project):
         """Rename a project in all affected frames."""
         if old_project not in self.projects:
-            raise WatsonError(u'Project "%s" does not exist' % old_project)
+            raise WatsonError('Project "%s" does not exist' % old_project)
 
         updated_at = arrow.utcnow()
         # rename project
@@ -568,7 +568,7 @@ class Watson(object):
     def rename_tag(self, old_tag, new_tag):
         """Rename a tag in all affected frames."""
         if old_tag not in self.tags:
-            raise WatsonError(u'Tag "%s" does not exist' % old_tag)
+            raise WatsonError('Tag "%s" does not exist' % old_tag)
 
         updated_at = arrow.utcnow()
         # rename tag

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -83,11 +83,11 @@ class Watson(object):
                 return type()
             else:
                 raise WatsonError(
-                    u"Invalid JSON file {}: {}".format(filename, e)
+                    "Invalid JSON file {}: {}".format(filename, e)
                 )
         except Exception as e:
             raise WatsonError(
-                u"Unexpected error while loading JSON file {}: {}".format(
+                "Unexpected error while loading JSON file {}: {}".format(
                     filename, e
                 )
             )
@@ -114,7 +114,7 @@ class Watson(object):
                 config.read(self.config_file)
             except CFGParserError as e:
                 raise ConfigurationError(
-                    u"Cannot parse config file: {}".format(e))
+                    "Cannot parse config file: {}".format(e))
 
             self._config = config
 
@@ -161,7 +161,7 @@ class Watson(object):
                           make_json_writer(self._format_date, self.last_sync))
         except OSError as e:
             raise WatsonError(
-                u"Impossible to write {}: {}".format(e.filename, e)
+                "Impossible to write {}: {}".format(e.filename, e)
             )
 
     @property
@@ -249,7 +249,7 @@ class Watson(object):
               gap=True):
         if self.is_started:
             raise WatsonError(
-                u"Project {} is already started.".format(
+                "Project {} is already started.".format(
                     self.current['project']
                 )
             )
@@ -332,7 +332,7 @@ class Watson(object):
         token = config.get('backend', 'token')
 
         if dest and token:
-            dest = u"{}/{}/".format(
+            dest = "{}/{}/".format(
                 dest.rstrip('/'),
                 route.strip('/')
             )
@@ -364,7 +364,7 @@ class Watson(object):
                 raise WatsonError("Unable to reach the server.")
             except AssertionError:
                 raise WatsonError(
-                    u"An error occurred with the remote "
+                    "An error occurred with the remote "
                     "server: {}".format(response.json())
                 )
 
@@ -383,7 +383,7 @@ class Watson(object):
             raise WatsonError("Unable to reach the server.")
         except AssertionError:
             raise WatsonError(
-                u"An error occurred with the remote "
+                "An error occurred with the remote "
                 "server: {}".format(response.json())
             )
 
@@ -423,8 +423,8 @@ class Watson(object):
             raise WatsonError("Unable to reach the server.")
         except AssertionError:
             raise WatsonError(
-                u"An error occurred with the remote server (status: {}). "
-                u"Response was:\n{}".format(
+                "An error occurred with the remote server (status: {}). "
+                "Response was:\n{}".format(
                     response.status_code,
                     response.text
                 )

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -6,11 +6,7 @@ import json
 import operator
 import os
 import uuid
-
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+from configparser import Error as CFGParserError
 import arrow
 import click
 
@@ -24,7 +20,7 @@ class WatsonError(RuntimeError):
     pass
 
 
-class ConfigurationError(configparser.Error, WatsonError):
+class ConfigurationError(CFGParserError, WatsonError):
     pass
 
 
@@ -118,7 +114,7 @@ class Watson(object):
             try:
                 config = ConfigParser()
                 config.read(self.config_file)
-            except configparser.Error as e:
+            except CFGParserError as e:
                 raise ConfigurationError(
                     u"Cannot parse config file: {}".format(e))
 

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import datetime
 from functools import reduce
 import json


### PR DESCRIPTION
Version 2.7 of Python soon will reach the end of its live. It already
hinders the application of new language features which are incompatible
with 2.7. Thus, stopping to support `python2.7.` is necessary.

All major distributions ship some version of the Python3 series already.
Thus, stopping to support `python2.7` should be relatively light in
trouble for users.