### PR TITLE
Set WATSON_DIR on virtualenv activation in fish script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ all: install
 $(VENV_DIR): requirements-dev.txt
 	$(VENV) $(VENV_ARGS) "$(VENV_DIR)"
 	echo "export WATSON_DIR=\"$(VENV_WATSON_DIR)\"" >> "$(VENV_DIR)"/bin/activate
+	echo "set -x WATSON_DIR \"$(VENV_WATSON_DIR)\"" >> "$(VENV_DIR)"/bin/activate.fish
 	"$(VENV_DIR)"/bin/pip install -U setuptools wheel pip
 	"$(VENV_DIR)"/bin/pip install -Ur $<
 

--- a/docs/contributing/hack.md
+++ b/docs/contributing/hack.md
@@ -33,6 +33,8 @@ Ready to contribute? Here's how to set up *Watson* for local development.
         $ source .venv/bin/activate
         (.venv) $ make install-dev
 
+    If you are using fish shell, source `.venv/bin/activate.fish` instead.
+
 5. Create a branch for local development:
 
         (.venv) $ git checkout -b name-of-your-bugfix-or-feature


### PR DESCRIPTION
Hey!

Just a small change to make dev experience with fish shell a bit more comfortable. Not sure if you like it or want to support fish (or have fish specifics in the docs). Would be nice to have this merged, but no strong feelings if you close the request :smile: 

This commit includes:
* Adds `set -x WATSON_DIR [...]` to `.venv/bin/activate.fish`, so that its also set when using fish specific activation script (similar to posix activation script).
* Adds hint for fish users in the docs about `activate.fish`.

If you prefer, I can split it into two commits, of course.