### PR TITLE
Add decimal formatting for durations

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -149,6 +149,15 @@ Globally configure how `dates` should be formatted. All [python's `strftime` dir
 
 Globally configure how `time` should be formatted. All [python's `strftime` directives](http://strftime.org) are supported.
 
+#### `options.durations_as_decimal`
+
+If `true` format durations as decimal number of hours, e.g. `1h 30m` becomes `1.50h`
+
+#### `options.decimal_precision`
+
+Default: `2`, defines with how many decimal places durations should be formatted. Only
+relevant if `options.durations_as_decimal` is true.
+
 #### `options.week_start`
 
 Globally configure which day corresponds to the start of a week. Allowable

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -633,6 +633,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
                 arrow.get(report['timespan']['from'])
             )),
             style('time', '{}'.format(format_timedelta(
+                watson,
                 datetime.timedelta(seconds=report['time'])
             )))
         ))
@@ -653,6 +654,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
         _print(u'{tab}{project} - {time}'.format(
             tab=tab,
             time=style('time', format_timedelta(
+                watson,
                 datetime.timedelta(seconds=project['time'])
             )),
             project=style('project', project['name'])
@@ -665,6 +667,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
             for tag in tags:
                 _print(u'\t[{tag} {time}]'.format(
                     time=style('time', '{:>11}'.format(format_timedelta(
+                        watson,
                         datetime.timedelta(seconds=tag['time'])
                     ))),
                     tag=style('tag', u'{:<{}}'.format(
@@ -678,6 +681,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
     if len(projects) > 1 and not aggregated:
         _print('Total: {}'.format(
             style('time', '{}'.format(format_timedelta(
+                watson,
                 datetime.timedelta(seconds=report['time'])
             )))
         ))
@@ -1016,13 +1020,14 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
         _print(
             "{date} ({daily_total})".format(
                 date=style('date', "{:dddd DD MMMM YYYY}".format(day)),
-                daily_total=style('time', format_timedelta(daily_total))
+                daily_total=style('time', format_timedelta(
+                    watson, daily_total))
             )
         )
 
         _print("\n".join(
             u"\t{id}  {start} to {stop}  {delta:>11}  {project}{tags}".format(
-                delta=format_timedelta(frame.stop - frame.start),
+                delta=format_timedelta(watson, frame.stop - frame.start),
                 project=style('project', u'{:>{}}'.format(
                     frame.project, longest_project
                 )),
@@ -1269,7 +1274,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
     click.echo(
         u"Edited frame for project {project}{tags}, from {start} to {stop} "
         u"({delta})".format(
-            delta=format_timedelta(stop - start) if stop else '-',
+            delta=format_timedelta(watson, stop - start) if stop else '-',
             project=style('project', project),
             tags=(" " if tags else "") + style('tags', tags),
             start=style(

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sys
 import tempfile
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -84,11 +85,15 @@ def style(name, element):
         return fmt(element)
 
 
-def format_timedelta(delta):
+def format_timedelta(watson, delta):
     """
     Return a string roughly representing a timedelta.
     """
     seconds = int(delta.total_seconds())
+
+    if watson.config.getboolean('options', 'format_as_decimal'):
+        return format_timedelta_decimal(watson, delta)
+
     neg = seconds < 0
     seconds = abs(seconds)
     total = seconds
@@ -107,6 +112,12 @@ def format_timedelta(delta):
     stems.append('{:02}s'.format(seconds))
 
     return ('-' if neg else '') + ' '.join(stems)
+
+
+def format_timedelta_decimal(watson, delta):
+    seconds = int(delta.total_seconds())
+    prec = watson.config.getint('options', 'decimal_precision', 2)
+    return '{:.{prec}f}h'.format(operator.truediv(seconds, 3600), prec=prec)
 
 
 def sorted_groupby(iterator, key, reverse=False):


### PR DESCRIPTION
Hi,

I've added functionality that allows timedeltas to be formatted as a decimal number instead of hours, minutes and seconds.
This is useful for users that want to calculate a price based on an hourly rate. For example `watson aggreate` now shows `4.50h` if you've tracked 4 hours and 30 minutes.

This feature is configurable via `watson config`. You can also set the decimal precision used for formatting the numbers.

I've also added documentation and tests for this feature.