### PR TITLE
Stylize prompt for new project and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- stylize prompt to create new project or tag (#310).
+- Stylize prompt to create new project or tag (#310).
 
 ## [1.8.0] - 2019-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- stylize prompt to create new project or tag (#310).
+
 ## [1.8.0] - 2019-08-26
 
 ### Added
 
 - Add CSV output format support for `report`, `log` and `aggregate` commands
   using the `--csv/-s` command line option flag (#281).
+- Add `start --confirm-new-project` and `start --confirm-new-tag` options and
+  corresponding options to configuration (#275).
 
 ### Fixed
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add CSV output format support for `report`, `log` and `aggregate` commands
   using the `--csv/-s` command line option flag (#281).
+- Add `start --confirm-new-project` and `start --confirm-new-tag` options and
+  corresponding options to configuration (#275).
 
 ### Fixed
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -234,7 +234,7 @@ def test_confirm_tags_reject_raises_abort(confirm):
     tags = ['c']
     watson_tags = ['a', 'b']
     with pytest.raises(Abort):
-        confirm_project(tags, watson_tags)
+        confirm_project(tags[0], watson_tags)
 
 
 # build_csv

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -218,7 +218,7 @@ def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
 
     if project and watson.is_started and not gap_:
         current = watson.current
-        errmsg = ("Project {} is already started and '--no-gap' is passed. "
+        errmsg = ("Project '{}' is already started and '--no-gap' is passed. "
                   "Please stop manually.")
         raise _watson.WatsonError(errmsg.format(current['project']))
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -35,7 +35,7 @@ def confirm_project(project, watson_projects):
     Returns True on accept and raises click.exceptions.Abort on reject
     """
     if project not in watson_projects:
-        msg = "Project '%s' does not exist yet. Create it?" % project
+        msg = "Project '%s' does not exist yet. Create it?" % style('project', project)
         click.confirm(msg, abort=True)
     return True
 
@@ -47,7 +47,7 @@ def confirm_tags(tags, watson_tags):
     """
     for tag in tags:
         if tag not in watson_tags:
-            msg = "Tag '%s' does not exist yet. Create it?" % tag
+            msg = "Tag '%s' does not exist yet. Create it?" % style('tag', tag)
             click.confirm(msg, abort=True)
     return True
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -32,6 +32,8 @@ except NameError:
 def confirm_project(project, watson_projects):
     """
     Ask user to confirm creation of a new project
+    'project' must be a string
+    'watson_projects' must be an interable.
     Returns True on accept and raises click.exceptions.Abort on reject
     """
     if project not in watson_projects:
@@ -44,6 +46,7 @@ def confirm_project(project, watson_projects):
 def confirm_tags(tags, watson_tags):
     """
     Ask user to confirm creation of new tags (each separately)
+    Both 'tags' and 'watson_tags" must be iterables.
     Returns True if all accepted and raises click.exceptions.Abort on reject
     """
     for tag in tags:

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -35,7 +35,8 @@ def confirm_project(project, watson_projects):
     Returns True on accept and raises click.exceptions.Abort on reject
     """
     if project not in watson_projects:
-        msg = "Project '%s' does not exist yet. Create it?" % style('project', project)
+        msg = ("Project '%s' does not exist yet. Create it?"
+               % style('project', project))
         click.confirm(msg, abort=True)
     return True
 


### PR DESCRIPTION
Further to #191 & #275, this stylizes the prompt to that the project or tag name is highlighted.

![image](https://user-images.githubusercontent.com/1548809/64462773-d3f62b80-d0be-11e9-9438-63c7cf58865f.png)

The other place this might make sense to add is when `Watson` displays an error message when you try to start a new project with `--no-gap` but have an active project ([cli.py, line 221-223](https://github.com/TailorDev/Watson/blob/master/watson/cli.py#L221-L223)); however, stylizing the project here breaks the colouring of the error message. This does update the typographical styling to be consistent with the above.

![image](https://user-images.githubusercontent.com/1548809/64462878-423aee00-d0bf-11e9-8358-0d09509deea6.png)

Further to #303, this also add these new options to the Release Notes for v1.8.0.