### PR TITLE
lazy import library "requests" to reduce response time

### DIFF
--- a/watson/watson.py
+++ b/watson/watson.py
@@ -13,7 +13,6 @@ except ImportError:
     import ConfigParser as configparser
 import arrow
 import click
-import requests
 
 from .config import ConfigParser
 from .frames import Frames
@@ -344,6 +343,8 @@ class Watson(object):
         return dest, headers
 
     def _get_remote_projects(self):
+        # import when required in order to reduce watson response time (#312)
+        import requests
         if not hasattr(self, '_remote_projects'):
             dest, headers = self._get_request_info('projects')
 
@@ -363,6 +364,7 @@ class Watson(object):
         return self._remote_projects['projects']
 
     def pull(self):
+        import requests
         dest, headers = self._get_request_info('frames')
 
         try:
@@ -392,6 +394,7 @@ class Watson(object):
         return frames
 
     def push(self, last_pull):
+        import requests
         dest, headers = self._get_request_info('frames/bulk')
 
         frames = []


### PR DESCRIPTION
I observed that it takes some response time for each command. On my personal PC, even the simplest command `watson help` takes 296ms to finish. By simple profiling, it comes out that most of the time was consumed on `import requests`. (please see [1] below)

Things get worse when the server has some proxy setting. For example, in the workstation at my office, a simple `import requests` takes me more than 1 second.

As `requests` is only used for `watson sync`, this import is not always necessary. Thus this PR is to propose that we could lazily import request, so that the general response time could be much lower (76ms in my case, see [2] below)

Some style guide suggests to always put import in the beginning of a file . An alternative method is using some lazy import technique like [this](https://wil.yegelwel.com/lazily-importing-python-modules/), if you prefer this style.

And thanks for this great work!

---

[1] import time for HEAD  
(`$ python -X importtime (which watson)`)
```python
import time: self [us] | cumulative | imported package
import time:       111 |        111 | zipimport
import time:       959 |        959 | _frozen_importlib_external
import time:        71 |         71 |     _codecs
import time:       789 |        860 |   codecs
import time:       730 |        730 |   encodings.aliases
import time:      1182 |       2772 | encodings
import time:       339 |        339 | encodings.utf_8
import time:       189 |        189 | _signal
import time:       484 |        484 | encodings.latin_1
import time:        74 |         74 |     _abc
import time:       464 |        538 |   abc
import time:       454 |        992 | io
import time:       106 |        106 |   _locale
import time:       299 |        405 | _bootlocale
import time:        84 |         84 |       _stat
import time:       434 |        518 |     stat
import time:       315 |        315 |       genericpath
import time:       795 |       1110 |     posixpath
import time:      1411 |       1411 |     _collections_abc
import time:       835 |       3874 |   os
import time:       331 |        331 |   _sitebuiltins
import time:       508 |        508 |   types
import time:       439 |        439 |       warnings
import time:       353 |        792 |     importlib
import time:       309 |        309 |       importlib.machinery
import time:       802 |       1111 |     importlib.abc
import time:        83 |         83 |           _operator
import time:      1035 |       1118 |         operator
import time:       272 |        272 |         keyword
import time:       988 |        988 |           _heapq
import time:       353 |       1341 |         heapq
import time:       141 |        141 |         itertools
import time:       335 |        335 |         reprlib
import time:       111 |        111 |         _collections
import time:      1349 |       4667 |       collections
import time:        69 |         69 |         _functools
import time:       826 |        895 |       functools
import time:       807 |       6369 |     contextlib
import time:       841 |       9113 |   importlib.util
import time:        99 |         99 |   sitecustomize
import time:        89 |         89 |   usercustomize
import time:      7080 |      21094 | site
import time:       948 |        948 |   enum
import time:        78 |         78 |     _sre
import time:       670 |        670 |       sre_constants
import time:       781 |       1451 |     sre_parse
import time:       483 |       2012 |   sre_compile
import time:       380 |        380 |   copyreg
import time:      1220 |       4560 | re
import time:       259 |        259 |         time
import time:       847 |        847 |         math
import time:       829 |        829 |         _datetime
import time:      1392 |       3327 |       datetime
import time:       715 |        715 |             _json
import time:       734 |       1449 |           json.scanner
import time:       821 |       2270 |         json.decoder
import time:       582 |        582 |         json.encoder
import time:       434 |       3286 |       json
import time:       123 |        123 |         _uuid
import time:       600 |        723 |       uuid
import time:       447 |        447 |         collections.abc
import time:      2182 |       2629 |       configparser
import time:       454 |        454 |         arrow._version
import time:       321 |        321 |           __future__
import time:      2198 |       2198 |               locale
import time:       945 |       3143 |             calendar
import time:       499 |        499 |               dateutil._version
import time:       442 |        941 |             dateutil
import time:       774 |        774 |                   _struct
import time:       331 |       1105 |                 struct
import time:       632 |        632 |                   _bisect
import time:       343 |        975 |                 bisect
import time:       425 |        425 |                   _weakrefset
import time:       686 |       1111 |                 weakref
import time:      1369 |       1369 |                 six
import time:        39 |         39 |                 six.moves
import time:       391 |        391 |                 dateutil.tz._common
import time:       367 |        367 |                 dateutil.tz._factories
import time:        39 |         39 |                   six.moves.winreg
import time:       432 |        471 |                 dateutil.tz.win
import time:       127 |        127 |                 contextmanager
import time:      1437 |       7392 |               dateutil.tz.tz
import time:       364 |       7756 |             dateutil.tz
import time:       641 |        641 |                       _opcode
import time:       494 |       1135 |                     opcode
import time:      1327 |       2462 |                   dis
import time:       333 |        333 |                       token
import time:      1293 |       1626 |                     tokenize
import time:       348 |       1974 |                   linecache
import time:      2270 |       6706 |                 inspect
import time:      2920 |       9626 |               arrow.locales
import time:      1936 |      11562 |             arrow.parser
import time:       317 |        317 |                 dateutil._common
import time:       450 |        767 |               dateutil.relativedelta
import time:       275 |        275 |                 arrow.util
import time:       764 |       1039 |               arrow.formatter
import time:       773 |       2579 |             arrow.arrow
import time:       471 |      26452 |           arrow.factory
import time:       300 |      27073 |         arrow.api
import time:       430 |      27957 |       arrow
import time:        96 |         96 |           errno
import time:       769 |        769 |             click._compat
import time:       496 |        496 |                     traceback
import time:       981 |       1477 |                   threading
import time:       304 |       1781 |                 click.globals
import time:       412 |       2193 |               click.utils
import time:       471 |       2664 |             click.exceptions
import time:       875 |       4308 |           click.types
import time:       472 |        472 |           click.termui
import time:       439 |        439 |             click.parser
import time:       390 |        829 |           click.formatting
import time:       296 |        296 |           click._unicodefun
import time:       464 |        464 |           click.decorators
import time:      1311 |       7776 |         click.core
import time:       454 |       8230 |       click
import time:        45 |         45 |                 _string
import time:      1039 |       1084 |               string
import time:        42 |         42 |               atexit
import time:      1412 |       2538 |             logging
import time:       965 |        965 |               _socket
import time:       699 |        699 |                 select
import time:       953 |       1652 |               selectors
import time:      1995 |       4612 |             socket
import time:      5139 |       5139 |                           _ssl
import time:      1337 |       1337 |                             binascii
import time:       628 |       1965 |                           base64
import time:      3565 |      10669 |                         ssl
import time:       677 |      11346 |                       urllib3.packages.ssl_match_hostname
import time:       379 |      11725 |                     urllib3.packages
import time:      1198 |      12923 |                   urllib3.packages.six
import time:        88 |      13011 |                 urllib3.packages.six.moves
import time:      1032 |       1032 |                   http
import time:       371 |        371 |                     email
import time:       883 |        883 |                       email.errors
import time:       453 |        453 |                           email.quoprimime
import time:       279 |        279 |                           email.base64mime
import time:       465 |        465 |                               quopri
import time:       348 |        813 |                             email.encoders
import time:       425 |       1238 |                           email.charset
import time:      1010 |       2980 |                         email.header
import time:      2098 |       2098 |                               _hashlib
import time:       676 |        676 |                               _blake2
import time:       976 |        976 |                               _sha3
import time:       728 |       4478 |                             hashlib
import time:       709 |        709 |                             _random
import time:       924 |       6111 |                           random
import time:       369 |        369 |                             urllib
import time:      1498 |       1867 |                           urllib.parse
import time:       450 |        450 |                           email._parseaddr
import time:       782 |       9210 |                         email.utils
import time:       543 |      12733 |                       email._policybase
import time:       808 |      14424 |                     email.feedparser
import time:       630 |      15425 |                   email.parser
import time:       359 |        359 |                     uu
import time:       503 |        503 |                     email._encoded_words
import time:       317 |        317 |                     email.iterators
import time:       919 |       2098 |                   email.message
import time:      1333 |      19888 |                 http.client
import time:        89 |      32988 |               urllib3.packages.six.moves.http_client
import time:      1051 |      34039 |             urllib3.exceptions
import time:       681 |        681 |               _queue
import time:       479 |       1160 |             queue
import time:       327 |        327 |                     urllib3.util.wait
import time:       304 |        304 |                     urllib3.contrib
import time:       434 |        434 |                     urllib3.contrib._appengine_environ
import time:       775 |       1840 |                   urllib3.util.connection
import time:       288 |        288 |                   urllib3.util.request
import time:       298 |        298 |                   urllib3.util.response
import time:       397 |        397 |                     hmac
import time:       404 |        801 |                   urllib3.util.ssl_
import time:       311 |        311 |                   urllib3.util.timeout
import time:       544 |        544 |                   urllib3.util.retry
import time:       463 |        463 |                   urllib3.util.url
import time:       568 |       5113 |                 urllib3.util
import time:        36 |       5149 |               urllib3.util.ssl_
import time:       535 |        535 |               urllib3._collections
import time:       505 |       6189 |             urllib3.connection
import time:       135 |        135 |                     winreg
import time:       532 |        667 |                   mimetypes
import time:      1959 |       2626 |                 urllib3.fields
import time:       359 |       2985 |               urllib3.filepost
import time:        35 |         35 |                 urllib3.packages.six.moves.urllib
import time:        53 |         88 |               urllib3.packages.six.moves.urllib.parse
import time:       358 |       3431 |             urllib3.request
import time:       762 |        762 |               zlib
import time:       692 |       1454 |             urllib3.response
import time:       302 |        302 |             urllib3.util.queue
import time:      1059 |      54784 |           urllib3.connectionpool
import time:       803 |        803 |           urllib3.poolmanager
import time:       570 |      56157 |         urllib3
import time:       482 |        482 |           chardet.compat
import time:       355 |        355 |               chardet.enums
import time:       316 |        316 |               chardet.charsetprober
import time:       351 |       1022 |             chardet.charsetgroupprober
import time:       383 |        383 |               chardet.codingstatemachine
import time:       288 |        288 |               chardet.escsm
import time:       360 |       1031 |             chardet.escprober
import time:       309 |        309 |             chardet.latin1prober
import time:       394 |        394 |                 chardet.mbcssm
import time:       359 |        753 |               chardet.utf8prober
import time:       323 |        323 |                 chardet.mbcharsetprober
import time:       875 |        875 |                   chardet.euctwfreq
import time:       537 |        537 |                   chardet.euckrfreq
import time:       613 |        613 |                   chardet.gb2312freq
import time:       797 |        797 |                   chardet.big5freq
import time:       670 |        670 |                   chardet.jisfreq
import time:       650 |       4142 |                 chardet.chardistribution
import time:       605 |        605 |                 chardet.jpcntx
import time:       459 |       5529 |               chardet.sjisprober
import time:       310 |        310 |               chardet.eucjpprober
import time:       304 |        304 |               chardet.gb2312prober
import time:       522 |        522 |               chardet.euckrprober
import time:       347 |        347 |               chardet.cp949prober
import time:       317 |        317 |               chardet.big5prober
import time:       288 |        288 |               chardet.euctwprober
import time:       506 |       8876 |             chardet.mbcsgroupprober
import time:       342 |        342 |               chardet.sbcharsetprober
import time:       456 |        456 |               chardet.langcyrillicmodel
import time:       405 |        405 |               chardet.langgreekmodel
import time:       459 |        459 |               chardet.langbulgarianmodel
import time:       401 |        401 |               chardet.langthaimodel
import time:       383 |        383 |               chardet.langhebrewmodel
import time:       367 |        367 |               chardet.hebrewprober
import time:       382 |        382 |               chardet.langturkishmodel
import time:       575 |       3770 |             chardet.sbcsgroupprober
import time:       601 |      15609 |           chardet.universaldetector
import time:       307 |        307 |           chardet.version
import time:       492 |      16890 |         chardet
import time:      1274 |       1274 |         requests.exceptions
import time:       422 |        422 |                   cryptography.__about__
import time:       464 |        886 |                 cryptography
import time:       716 |        716 |                   cryptography.x509.certificate_transparency
import time:       408 |        408 |                     cryptography.utils
import time:       308 |        308 |                         cryptography.hazmat
import time:       491 |        799 |                       cryptography.hazmat.primitives
import time:       625 |       1424 |                     cryptography.hazmat.primitives.asymmetric
import time:      1472 |       1472 |                     cryptography.hazmat.primitives.asymmetric.dsa
import time:       339 |        339 |                       cryptography.hazmat._oid
import time:      1279 |       1618 |                     cryptography.hazmat.primitives.asymmetric.ec
import time:       605 |        605 |                       cryptography.exceptions
import time:       341 |        341 |                         cryptography.hazmat.backends
import time:      1125 |       1466 |                       cryptography.hazmat.backends.interfaces
import time:       694 |       2765 |                     cryptography.hazmat.primitives.asymmetric.rsa
import time:      1826 |       1826 |                       ipaddress
import time:       438 |        438 |                           asn1crypto.version
import time:       399 |        837 |                         asn1crypto
import time:      1421 |       1421 |                                 signal
import time:       787 |        787 |                                 _posixsubprocess
import time:       840 |       3048 |                               subprocess
import time:      2711 |       5759 |                             platform
import time:      1317 |       1317 |                                 textwrap
import time:       305 |       1622 |                               asn1crypto._errors
import time:       882 |        882 |                                     unicodedata
import time:       699 |       1581 |                                   stringprep
import time:      1617 |       3198 |                                 encodings.idna
import time:       294 |        294 |                                 asn1crypto._types
import time:       429 |       3921 |                               asn1crypto._iri
import time:       306 |        306 |                               asn1crypto._ordereddict
import time:       532 |       6381 |                             asn1crypto.util
import time:      1481 |       1481 |                                 _ctypes
import time:       520 |        520 |                                 ctypes._endian
import time:      1628 |       3629 |                               ctypes
import time:       329 |       3958 |                             asn1crypto._ffi
import time:       307 |        307 |                               asn1crypto._perf
import time:       335 |        335 |                                   fnmatch
import time:       412 |        412 |                                     _compression
import time:       749 |        749 |                                     _bz2
import time:       549 |       1710 |                                   bz2
import time:      1224 |       1224 |                                     _lzma
import time:       979 |       2203 |                                   lzma
import time:        61 |         61 |                                   pwd
import time:       661 |        661 |                                   grp
import time:       866 |       5836 |                                 shutil
import time:       649 |        649 |                                 tempfile
import time:       389 |       6874 |                               ctypes.util
import time:     39826 |      47007 |                             asn1crypto._perf._big_num_ctypes
import time:       664 |      63769 |                           asn1crypto._int
import time:       639 |      64408 |                         asn1crypto._elliptic_curve
import time:       247 |        247 |                                   org
import time:        58 |        305 |                                 org.python
import time:        47 |        352 |                               org.python.core
import time:       578 |        930 |                             copy
import time:       493 |        493 |                             asn1crypto._teletex_codec
import time:       318 |        318 |                             asn1crypto.parser
import time:      3906 |       5647 |                           asn1crypto.core
import time:      1931 |       7578 |                         asn1crypto.algos
import time:      1425 |      74248 |                       asn1crypto.keys
import time:       344 |        344 |                           cryptography.hazmat.bindings
import time:      1578 |       1578 |                           _cffi_backend
import time:      1060 |       2982 |                         cryptography.hazmat.bindings._constant_time
import time:       397 |       3379 |                       cryptography.hazmat.primitives.constant_time
import time:      1232 |       1232 |                         cryptography.hazmat.primitives.serialization.base
import time:       440 |        440 |                           cryptography.hazmat.primitives.asymmetric.ed25519
import time:       406 |        846 |                         cryptography.hazmat.primitives.serialization.ssh
import time:       465 |       2543 |                       cryptography.hazmat.primitives.serialization
import time:      1172 |       1172 |                             cryptography.hazmat.primitives.hashes
import time:       949 |       2121 |                           cryptography.x509.oid
import time:       739 |       2860 |                         cryptography.x509.name
import time:       791 |       3651 |                       cryptography.x509.general_name
import time:      2710 |      88357 |                     cryptography.x509.extensions
import time:      1296 |      97340 |                   cryptography.x509.base
import time:       624 |      98680 |                 cryptography.x509
import time:       338 |        338 |                     cryptography.hazmat.bindings.openssl
import time:      1611 |       1611 |                     cryptography.hazmat.bindings._openssl
import time:       475 |        475 |                     cryptography.hazmat.bindings.openssl._conditional
import time:      6114 |       8538 |                   cryptography.hazmat.bindings.openssl.binding
import time:       439 |       8977 |                 OpenSSL._util
import time:      2054 |     110597 |               OpenSSL.crypto
import time:      1624 |       1624 |               OpenSSL.SSL
import time:       285 |        285 |               OpenSSL.version
import time:       565 |     113071 |             OpenSSL
import time:        51 |     113122 |           OpenSSL.SSL
import time:       327 |        327 |               cryptography.hazmat.backends.openssl.aead
import time:      1106 |       1106 |                     cryptography.hazmat.primitives.ciphers.modes
import time:      1076 |       2182 |                   cryptography.hazmat.primitives.ciphers.base
import time:       361 |       2543 |                 cryptography.hazmat.primitives.ciphers
import time:       550 |       3093 |               cryptography.hazmat.backends.openssl.ciphers
import time:       343 |        343 |               cryptography.hazmat.backends.openssl.cmac
import time:       656 |        656 |               cryptography.hazmat.backends.openssl.decode_asn1
import time:       566 |        566 |                 cryptography.hazmat.primitives.asymmetric.dh
import time:       870 |       1436 |               cryptography.hazmat.backends.openssl.dh
import time:       311 |        311 |                   cryptography.hazmat.primitives.asymmetric.utils
import time:       339 |        650 |                 cryptography.hazmat.backends.openssl.utils
import time:       958 |       1608 |               cryptography.hazmat.backends.openssl.dsa
import time:      1076 |       1076 |               cryptography.hazmat.backends.openssl.ec
import time:       525 |        525 |               cryptography.hazmat.backends.openssl.ed25519
import time:       388 |        388 |                 cryptography.hazmat.primitives.asymmetric.ed448
import time:       583 |        971 |               cryptography.hazmat.backends.openssl.ed448
import time:       530 |        530 |               cryptography.hazmat.backends.openssl.encode_asn1
import time:       529 |        529 |               cryptography.hazmat.backends.openssl.hashes
import time:       460 |        460 |               cryptography.hazmat.backends.openssl.hmac
import time:      2335 |       2335 |                 cryptography.hazmat.backends.openssl.x509
import time:      1022 |       1022 |                 cryptography.x509.ocsp
import time:       751 |       4108 |               cryptography.hazmat.backends.openssl.ocsp
import time:       318 |        318 |               cryptography.hazmat.backends.openssl.poly1305
import time:       409 |        409 |                 cryptography.hazmat.primitives.asymmetric.padding
import time:      1122 |       1531 |               cryptography.hazmat.backends.openssl.rsa
import time:       501 |        501 |                 cryptography.hazmat.primitives.asymmetric.x25519
import time:       562 |       1063 |               cryptography.hazmat.backends.openssl.x25519
import time:       406 |        406 |                 cryptography.hazmat.primitives.asymmetric.x448
import time:       580 |        986 |               cryptography.hazmat.backends.openssl.x448
import time:       678 |        678 |               cryptography.hazmat.primitives.ciphers.algorithms
import time:       386 |        386 |               cryptography.hazmat.primitives.kdf
import time:       698 |        698 |               cryptography.hazmat.primitives.kdf.scrypt
import time:      4134 |      25456 |             cryptography.hazmat.backends.openssl.backend
import time:       402 |      25858 |           cryptography.hazmat.backends.openssl
import time:        70 |         70 |           cryptography.x509.UnsupportedExtension
import time:       344 |        344 |             urllib3.packages.backports
import time:       487 |        831 |           urllib3.packages.backports.makefile
import time:       865 |     140746 |         urllib3.contrib.pyopenssl
import time:       288 |        288 |         requests.__version__
import time:      1337 |       1337 |           zipfile
import time:       507 |        507 |               certifi.core
import time:       429 |        936 |             certifi
import time:       299 |       1235 |           requests.certs
import time:       128 |        128 |               simplejson
import time:       368 |        368 |                   urllib.response
import time:       431 |        799 |                 urllib.error
import time:      2091 |       2890 |               urllib.request
import time:      3842 |       3842 |               http.cookiejar
import time:      1751 |       1751 |               http.cookies
import time:       483 |       9094 |             requests.compat
import time:       316 |       9410 |           requests._internal_utils
import time:       630 |        630 |           requests.cookies
import time:       340 |        340 |           requests.structures
import time:       920 |      13872 |         requests.utils
import time:       465 |        465 |             idna.package_data
import time:       583 |        583 |               idna.idnadata
import time:       267 |        267 |               idna.intranges
import time:       525 |       1375 |             idna.core
import time:       428 |       2268 |           idna
import time:       762 |       3030 |         requests.packages
import time:       303 |        303 |           requests.hooks
import time:       559 |        559 |           requests.auth
import time:       602 |        602 |           requests.status_codes
import time:       914 |       2378 |         requests.models
import time:       972 |        972 |                 socks
import time:       469 |       1441 |               urllib3.contrib.socks
import time:       665 |       2106 |             requests.adapters
import time:       741 |       2847 |           requests.sessions
import time:       349 |       3196 |         requests.api
import time:      1054 |     238885 |       requests
import time:       582 |        582 |         shlex
import time:       389 |        971 |       watson.config
import time:       554 |        554 |       watson.frames
import time:       834 |        834 |           _csv
import time:       684 |       1518 |         csv
import time:       133 |        133 |         StringIO
import time:       475 |        475 |         watson.fullmoon
import time:       511 |       2637 |       watson.utils
import time:       258 |        258 |       watson.version
import time:      1133 |     290590 |     watson.watson
import time:       538 |     291128 |   watson
import time:      3279 |       3279 |   watson.cli
import time:       324 |        324 |   click._textwrap
Usage: watson [OPTIONS] COMMAND [ARGS]...

  Watson is a tool aimed at helping you monitoring your time.

  You just have to tell Watson when you start working on your project with
  the `start` command, and you can stop the timer when you're done with the
  `stop` command.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  add        Add time for project with tag(s) that was not tracked live.
  aggregate  Display a report of the time spent on each project aggregated...
  cancel     Cancel the last call to the start command.
  config     Get and set configuration options.
  edit       Edit a frame.
  frames     Display the list of all frame IDs.
  help       Display help information
  log        Display each recorded session during the given timespan.
  merge      Perform a merge of the existing frames with a conflicting...
  projects   Display the list of all the existing projects.
  remove     Remove a frame.
  rename     Rename a project or tag.
  report     Display a report of the time spent on each project.
  restart    Restart monitoring time for a previously stopped project.
  start      Start monitoring time for the given project.
  status     Display when the current project was started and the time
             spent...
  stop       Stop monitoring time for the current project.
  sync       Get the frames from the server and push the new ones.
  tags       Display the list of all the tags.
import time:      1782 |     296513 | watson.__main__
```

[2] impot time after this patch
```python
import time: self [us] | cumulative | imported package
import time:       107 |        107 | zipimport
import time:       823 |        823 | _frozen_importlib_external
import time:        74 |         74 |     _codecs
import time:       799 |        873 |   codecs
import time:       734 |        734 |   encodings.aliases
import time:      1213 |       2820 | encodings
import time:       353 |        353 | encodings.utf_8
import time:       193 |        193 | _signal
import time:       438 |        438 | encodings.latin_1
import time:        47 |         47 |     _abc
import time:       456 |        503 |   abc
import time:       468 |        971 | io
import time:       109 |        109 |   _locale
import time:       326 |        435 | _bootlocale
import time:        87 |         87 |       _stat
import time:       449 |        536 |     stat
import time:       326 |        326 |       genericpath
import time:       775 |       1101 |     posixpath
import time:      1410 |       1410 |     _collections_abc
import time:       887 |       3934 |   os
import time:       367 |        367 |   _sitebuiltins
import time:       478 |        478 |   types
import time:       432 |        432 |       warnings
import time:       349 |        781 |     importlib
import time:       312 |        312 |       importlib.machinery
import time:       718 |       1030 |     importlib.abc
import time:        84 |         84 |           _operator
import time:       988 |       1072 |         operator
import time:       285 |        285 |         keyword
import time:       975 |        975 |           _heapq
import time:       345 |       1320 |         heapq
import time:       146 |        146 |         itertools
import time:       348 |        348 |         reprlib
import time:        87 |         87 |         _collections
import time:      1354 |       4612 |       collections
import time:        72 |         72 |         _functools
import time:       884 |        956 |       functools
import time:       794 |       6362 |     contextlib
import time:       727 |       8900 |   importlib.util
import time:       104 |        104 |   sitecustomize
import time:        93 |         93 |   usercustomize
import time:      7152 |      21028 | site
import time:       943 |        943 |   enum
import time:        79 |         79 |     _sre
import time:       525 |        525 |       sre_constants
import time:       765 |       1290 |     sre_parse
import time:       537 |       1906 |   sre_compile
import time:       349 |        349 |   copyreg
import time:      1221 |       4419 | re
import time:       259 |        259 |         time
import time:       844 |        844 |         math
import time:       837 |        837 |         _datetime
import time:      1427 |       3367 |       datetime
import time:       698 |        698 |             _json
import time:       739 |       1437 |           json.scanner
import time:       790 |       2227 |         json.decoder
import time:       586 |        586 |         json.encoder
import time:       427 |       3240 |       json
import time:       122 |        122 |         _uuid
import time:       544 |        666 |       uuid
import time:       450 |        450 |         collections.abc
import time:      2094 |       2544 |       configparser
import time:       441 |        441 |         arrow._version
import time:       322 |        322 |           __future__
import time:      2023 |       2023 |               locale
import time:       988 |       3011 |             calendar
import time:       580 |        580 |               dateutil._version
import time:       472 |       1052 |             dateutil
import time:       925 |        925 |                   _struct
import time:       362 |       1287 |                 struct
import time:       665 |        665 |                   _bisect
import time:       374 |       1039 |                 bisect
import time:       440 |        440 |                   _weakrefset
import time:       702 |       1142 |                 weakref
import time:      1428 |       1428 |                 six
import time:        41 |         41 |                 six.moves
import time:       402 |        402 |                 dateutil.tz._common
import time:       375 |        375 |                 dateutil.tz._factories
import time:        49 |         49 |                   six.moves.winreg
import time:       419 |        468 |                 dateutil.tz.win
import time:       127 |        127 |                 contextmanager
import time:      1647 |       7956 |               dateutil.tz.tz
import time:       372 |       8328 |             dateutil.tz
import time:       736 |        736 |                       _opcode
import time:       563 |       1299 |                     opcode
import time:      1370 |       2669 |                   dis
import time:       385 |        385 |                       token
import time:      1525 |       1910 |                     tokenize
import time:       349 |       2259 |                   linecache
import time:      2158 |       7086 |                 inspect
import time:      2932 |      10018 |               arrow.locales
import time:      1909 |      11927 |             arrow.parser
import time:       315 |        315 |                 dateutil._common
import time:       456 |        771 |               dateutil.relativedelta
import time:       279 |        279 |                 arrow.util
import time:       799 |       1078 |               arrow.formatter
import time:       722 |       2571 |             arrow.arrow
import time:       453 |      27342 |           arrow.factory
import time:       304 |      27968 |         arrow.api
import time:       432 |      28841 |       arrow
import time:        96 |         96 |           errno
import time:       734 |        734 |             click._compat
import time:       505 |        505 |                     traceback
import time:       983 |       1488 |                   threading
import time:       320 |       1808 |                 click.globals
import time:       408 |       2216 |               click.utils
import time:       499 |       2715 |             click.exceptions
import time:       877 |       4326 |           click.types
import time:       482 |        482 |           click.termui
import time:       440 |        440 |             click.parser
import time:       398 |        838 |           click.formatting
import time:       311 |        311 |           click._unicodefun
import time:       461 |        461 |           click.decorators
import time:      1337 |       7851 |         click.core
import time:       470 |       8321 |       click
import time:       485 |        485 |         shlex
import time:       378 |        863 |       watson.config
import time:       533 |        533 |       watson.frames
import time:       818 |        818 |           _csv
import time:       589 |       1407 |         csv
import time:       344 |        344 |           fnmatch
import time:      1999 |       1999 |           zlib
import time:       412 |        412 |             _compression
import time:       715 |        715 |             _bz2
import time:       473 |       1600 |           bz2
import time:      1345 |       1345 |             _lzma
import time:       946 |       2291 |           lzma
import time:        51 |         51 |           pwd
import time:       648 |        648 |           grp
import time:      1298 |       8231 |         shutil
import time:      4570 |       4570 |               _hashlib
import time:       758 |        758 |               _blake2
import time:       747 |        747 |               _sha3
import time:       737 |       6812 |             hashlib
import time:       647 |        647 |             _random
import time:       805 |       8264 |           random
import time:       714 |       8978 |         tempfile
import time:       132 |        132 |         StringIO
import time:       513 |        513 |         watson.fullmoon
import time:       521 |      19782 |       watson.utils
import time:       263 |        263 |       watson.version
import time:       981 |      69401 |     watson.watson
import time:       522 |      69923 |   watson
import time:      2896 |       2896 |   watson.cli
import time:      1370 |       1370 |     textwrap
import time:       360 |       1730 |   click._textwrap
Usage: watson [OPTIONS] COMMAND [ARGS]...

  Watson is a tool aimed at helping you monitoring your time.

  You just have to tell Watson when you start working on your project with
  the `start` command, and you can stop the timer when you're done with the
  `stop` command.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  add        Add time for project with tag(s) that was not tracked live.
  aggregate  Display a report of the time spent on each project aggregated...
  cancel     Cancel the last call to the start command.
  config     Get and set configuration options.
  edit       Edit a frame.
  frames     Display the list of all frame IDs.
  help       Display help information
  log        Display each recorded session during the given timespan.
  merge      Perform a merge of the existing frames with a conflicting...
  projects   Display the list of all the existing projects.
  remove     Remove a frame.
  rename     Rename a project or tag.
  report     Display a report of the time spent on each project.
  restart    Restart monitoring time for a previously stopped project.
  start      Start monitoring time for the given project.
  status     Display when the current project was started and the time
             spent...
  stop       Stop monitoring time for the current project.
  sync       Get the frames from the server and push the new ones.
  tags       Display the list of all the tags.
import time:      1558 |      76107 | watson.__main__
```