### PR TITLE
Review usage of arrow.get() for Arrow 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
+
 ### Fixed
 
 - Stylize prompt to create new project or tag (#310).

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -75,7 +75,7 @@ class DateParamType(click.ParamType):
         if value:
             try:
                 date = arrow.get(value)
-            except arrow.parser.ParserError as e:
+            except (ValueError, TypeError) as e:
                 raise click.UsageError(str(e))
             # When we parse a date, we want to parse it in the timezone
             # expected by the user, so that midnight is midnight in the local
@@ -630,7 +630,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
     if aggregated:
         _print(u'{} - {}'.format(
             style('date', '{:ddd DD MMMM YYYY}'.format(
-                arrow.get(report['timespan']['from'])
+                report['timespan']['from']
             )),
             style('time', '{}'.format(format_timedelta(
                 datetime.timedelta(seconds=report['time'])
@@ -640,10 +640,10 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
     else:
         _print(u'{} -> {}\n'.format(
             style('date', '{:ddd DD MMMM YYYY}'.format(
-                arrow.get(report['timespan']['from'])
+                report['timespan']['from']
             )),
             style('date', '{:ddd DD MMMM YYYY}'.format(
-                arrow.get(report['timespan']['to'])
+                report['timespan']['to']
             ))
         ))
 
@@ -1244,7 +1244,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
             # break out of while loop and continue execution of
             #  the edit function normally
             break
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, TypeError, RuntimeError) as e:
             click.echo(u"Error while parsing inputted values: {}".format(e),
                        err=True)
         except KeyError:

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -15,17 +15,17 @@ class Frame(namedtuple('Frame', HEADERS)):
 
             if not isinstance(stop, arrow.Arrow):
                 stop = arrow.get(stop)
-        except RuntimeError as e:
+
+            if updated_at is None:
+                updated_at = arrow.utcnow()
+            elif not isinstance(updated_at, arrow.Arrow):
+                updated_at = arrow.get(updated_at)
+        except (ValueError, TypeError) as e:
             from .watson import WatsonError
             raise WatsonError(u"Error converting date: {}".format(e))
 
         start = start.to('local')
         stop = stop.to('local')
-
-        if updated_at is None:
-            updated_at = arrow.utcnow()
-        elif not isinstance(updated_at, arrow.Arrow):
-            updated_at = arrow.get(updated_at)
 
         if tags is None:
             tags = []

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -378,12 +378,8 @@ def flatten_report_for_csv(report):
     of the report.
     """
     result = []
-    datetime_from = arrow.get(
-            report['timespan']['from']
-    ).format('YYYY-MM-DD HH:mm:ss')
-    datetime_to = arrow.get(
-            report['timespan']['to']
-    ).format('YYYY-MM-DD HH:mm:ss')
+    datetime_from = report['timespan']['from'].format('YYYY-MM-DD HH:mm:ss')
+    datetime_to = report['timespan']['to'].format('YYYY-MM-DD HH:mm:ss')
     for project in report['projects']:
         result.append({
             'from': datetime_from,

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -99,9 +99,11 @@ class Watson(object):
             )
 
     def _parse_date(self, date):
+        """Returns Arrow object from timestamp."""
         return arrow.Arrow.utcfromtimestamp(date).to('local')
 
     def _format_date(self, date):
+        """Returns timestamp from string timestamp or Arrow object."""
         if not isinstance(date, arrow.Arrow):
             date = arrow.get(date)
 
@@ -494,8 +496,8 @@ class Watson(object):
 
         report = {
              'timespan': {
-                 'from': str(span.start),
-                 'to': str(span.stop),
+                 'from': span.start,
+                 'to': span.stop,
              },
              'projects': []
          }


### PR DESCRIPTION
[Arrow 0.15.0](https://github.com/crsmithdev/arrow/blob/master/CHANGELOG.md#0150) has been recently released and the warning messages mentioned in #296 have disappeared.

After reading the comments in that issue and reviewing the code, it seems to me that only user date input can be affected for some commands. For example, **if someone relied on using timestamps in the command line, errors will probably be raised with Arrow 0.15.0**.
 
@ryanmjacobs It would be great if you could review my changes and compare them with those you made a month ago :relieved: 

**Changes**:
- Reduce the number of uses of `arrow.get()` related to spans in reports.
- Unify catched exceptions when calling `arrow.get()`.
- Include `Frame.updated_at` parsing inside `try/catch` just like
start/stop.