### PR TITLE
Unify WatsonError catching in cli.py

### DIFF
--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -317,7 +317,7 @@ def test_stop_started_project_at(watson):
     watson.start('foo')
     now = arrow.now()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(WatsonError):
         time_str = '1970-01-01T00:00'
         time_obj = arrow.get(time_str)
         watson.stop(stop_at=time_obj)

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -8,7 +8,7 @@ import os
 import re
 
 from dateutil import tz
-from functools import reduce
+from functools import reduce, wraps
 
 import arrow
 import click
@@ -52,20 +52,12 @@ class MutuallyExclusiveOption(click.Option):
         # Use self.opts[-1] instead of self.name to handle options with a
         # different internal name.
         self.mutually_exclusive.add(self.opts[-1].strip('-'))
-        raise click.UsageError(
-            'The following options are mutually exclusive: '
-            '{options}'.format(options=', '
-                               .join(['`--{}`'.format(_) for _ in
-                                     self.mutually_exclusive]))
-        )
-
-
-class WatsonCliError(click.ClickException):
-    def format_message(self):
-        return style('error', self.message)
-
-
-_watson.WatsonError = WatsonCliError
+        raise click.ClickException(
+            style(
+                'error',
+                'The following options are mutually exclusive: '
+                '{options}'.format(options=', '.join(
+                    ['`--{}`'.format(_) for _ in self.mutually_exclusive]))))
 
 
 class DateParamType(click.ParamType):
@@ -110,7 +102,7 @@ class TimeParamType(click.ParamType):
         else:
             errmsg = ('Could not parse time.'
                       'Please specify in (YYYY-MM-DDT)?HH:MM(:SS)? format.')
-            raise WatsonCliError(errmsg)
+            raise click.ClickException(style('error', errmsg))
 
         local_tz = tz.tzlocal()
         return arrow.get(cur_time).replace(tzinfo=local_tz)
@@ -118,6 +110,16 @@ class TimeParamType(click.ParamType):
 
 Date = DateParamType()
 Time = TimeParamType()
+
+
+def catch_watson_error(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except _watson.WatsonError as e:
+            raise click.ClickException(style('error', str(e)))
+    return wrapper
 
 
 @click.group()
@@ -180,6 +182,7 @@ def _start(watson, project, tags, restart=False, gap=True):
               help="Confirm creation of new tag.")
 @click.pass_obj
 @click.pass_context
+@catch_watson_error
 def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
     """
     Start monitoring time for the given project.
@@ -220,7 +223,11 @@ def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
         current = watson.current
         errmsg = ("Project '{}' is already started and '--no-gap' is passed. "
                   "Please stop manually.")
-        raise _watson.WatsonError(errmsg.format(current['project']))
+        raise click.ClickException(
+            style(
+                'error', errmsg.format(current['project'])
+            )
+        )
 
     if (project and watson.is_started and
             watson.config.getboolean('options', 'stop_on_start')):
@@ -234,6 +241,7 @@ def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
               help=('Stop frame at this time. Must be in '
                     '(YYYY-MM-DDT)?HH:MM(:SS)? format.'))
 @click.pass_obj
+@catch_watson_error
 def stop(watson, at_):
     """
     Stop monitoring time for the current project.
@@ -266,6 +274,7 @@ def stop(watson, at_):
 @click.argument('frame', default='-1')
 @click.pass_obj
 @click.pass_context
+@catch_watson_error
 def restart(ctx, watson, frame, stop_):
     """
     Restart monitoring time for a previously stopped project.
@@ -319,6 +328,7 @@ def restart(ctx, watson, frame, stop_):
 
 @cli.command()
 @click.pass_obj
+@catch_watson_error
 def cancel(watson):
     """
     Cancel the last call to the start command. The time will
@@ -340,6 +350,7 @@ def cancel(watson):
 @click.option('-e', '--elapsed', is_flag=True,
               help="only show time elapsed")
 @click.pass_obj
+@catch_watson_error
 def status(watson, project, tags, elapsed):
     """
     Display when the current project was started and the time spent since.
@@ -468,6 +479,7 @@ _SHORTCUT_OPTIONS_VALUES = {
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
 @click.pass_obj
+@catch_watson_error
 def report(watson, current, from_, to, projects, tags, ignore_projects,
            ignore_tags, year, month, week, day, luna, all, output_format,
            pager, aggregated=False):
@@ -584,13 +596,10 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
     else:
         tab = ''
 
-    try:
-        report = watson.report(from_, to, current, projects, tags,
-                               ignore_projects, ignore_tags,
-                               year=year, month=month, week=week, day=day,
-                               luna=luna, all=all)
-    except _watson.WatsonError as e:
-        raise click.ClickException(e.message)
+    report = watson.report(from_, to, current, projects, tags,
+                           ignore_projects, ignore_tags,
+                           year=year, month=month, week=week, day=day,
+                           luna=luna, all=all)
 
     if 'json' in output_format and not aggregated:
         click.echo(json.dumps(report, indent=4, sort_keys=True))
@@ -726,6 +735,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 @click.pass_context
+@catch_watson_error
 def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
               pager):
     """
@@ -887,6 +897,7 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
 @click.pass_obj
+@catch_watson_error
 def log(watson, current, from_, to, projects, tags, year, month, week, day,
         luna, all, output_format, pager):
     """
@@ -1040,6 +1051,7 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
 
 @cli.command()
 @click.pass_obj
+@catch_watson_error
 def projects(watson):
     """
     Display the list of all the existing projects.
@@ -1059,6 +1071,7 @@ def projects(watson):
 
 @cli.command()
 @click.pass_obj
+@catch_watson_error
 def tags(watson):
     """
     Display the list of all the tags.
@@ -1086,6 +1099,7 @@ def tags(watson):
 
 @cli.command()
 @click.pass_obj
+@catch_watson_error
 def frames(watson):
     """
     Display the list of all frame IDs.
@@ -1114,6 +1128,7 @@ def frames(watson):
 @click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
               help="Confirm creation of new tag.")
 @click.pass_obj
+@catch_watson_error
 def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
     """
     Add time for project with tag(s) that was not tracked live.
@@ -1163,6 +1178,7 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
               help="Confirm creation of new tag.")
 @click.argument('id', required=False)
 @click.pass_obj
+@catch_watson_error
 def edit(watson, confirm_new_project, confirm_new_tag, id):
     """
     Edit a frame.
@@ -1289,6 +1305,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
 @click.option('-f', '--force', is_flag=True,
               help="Don't ask for confirmation.")
 @click.pass_obj
+@catch_watson_error
 def remove(watson, id, force):
     """
     Remove a frame. You can specify the frame either by id or by position
@@ -1321,6 +1338,7 @@ def remove(watson, id, force):
 @click.option('-e', '--edit', is_flag=True,
               help="Edit the configuration file with an editor.")
 @click.pass_context
+@catch_watson_error
 def config(context, key, value, edit):
     """
     Get and set configuration options.
@@ -1358,7 +1376,7 @@ def config(context, key, value, edit):
         except _watson.ConfigurationError as exc:
             watson.config = wconfig
             watson.save()
-            raise WatsonCliError(str(exc))
+            raise click.ClickException(style('error', str(exc)))
         return
 
     if not key:
@@ -1393,6 +1411,7 @@ def config(context, key, value, edit):
 
 @cli.command()
 @click.pass_obj
+@catch_watson_error
 def sync(watson):
     """
     Get the frames from the server and push the new ones.
@@ -1426,6 +1445,7 @@ def sync(watson):
               help="If specified, then the merge will automatically "
               "be performed.")
 @click.pass_obj
+@catch_watson_error
 def merge(watson, frames_with_conflict, force):
     """
     Perform a merge of the existing frames with a conflicting frames file.
@@ -1578,6 +1598,7 @@ def merge(watson, frames_with_conflict, force):
 @click.argument('old_name', required=True)
 @click.argument('new_name', required=True)
 @click.pass_obj
+@catch_watson_error
 def rename(watson, rename_type, old_name, new_name):
     """
     Rename a project or tag.
@@ -1592,25 +1613,17 @@ def rename(watson, rename_type, old_name, new_name):
 
     """
     if rename_type == 'tag':
-        try:
-            watson.rename_tag(old_name, new_name)
-        except ValueError as e:
-            raise click.ClickException(style('error', str(e)))
-        else:
-            click.echo(u'Renamed tag "{}" to "{}"'.format(
-                            style('tag', old_name),
-                            style('tag', new_name)
-                       ))
+        watson.rename_tag(old_name, new_name)
+        click.echo(u'Renamed tag "{}" to "{}"'.format(
+                        style('tag', old_name),
+                        style('tag', new_name)
+                   ))
     elif rename_type == 'project':
-        try:
-            watson.rename_project(old_name, new_name)
-        except ValueError as e:
-            raise click.ClickException(style('error', str(e)))
-        else:
-            click.echo(u'Renamed project "{}" to "{}"'.format(
-                            style('project', old_name),
-                            style('project', new_name)
-                       ))
+        watson.rename_project(old_name, new_name)
+        click.echo(u'Renamed project "{}" to "{}"'.format(
+                        style('project', old_name),
+                        style('project', new_name)
+                   ))
     else:
         raise click.ClickException(style(
             'error',

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -287,9 +287,9 @@ class Watson(object):
             # outdated if defined using a default argument.
             stop_at = arrow.now()
         if old['start'] > stop_at:
-            raise ValueError('Task cannot end before it starts.')
+            raise WatsonError('Task cannot end before it starts.')
         if stop_at > arrow.now():
-            raise ValueError('Task cannot end in the future.')
+            raise WatsonError('Task cannot end in the future.')
 
         frame = self.frames.add(
             old['project'], old['start'], stop_at, tags=old['tags']
@@ -545,7 +545,7 @@ class Watson(object):
     def rename_project(self, old_project, new_project):
         """Rename a project in all affected frames."""
         if old_project not in self.projects:
-            raise ValueError(u'Project "%s" does not exist' % old_project)
+            raise WatsonError(u'Project "%s" does not exist' % old_project)
 
         updated_at = arrow.utcnow()
         # rename project
@@ -562,7 +562,7 @@ class Watson(object):
     def rename_tag(self, old_tag, new_tag):
         """Rename a tag in all affected frames."""
         if old_tag not in self.tags:
-            raise ValueError(u'Tag "%s" does not exist' % old_tag)
+            raise WatsonError(u'Tag "%s" does not exist' % old_tag)
 
         updated_at = arrow.utcnow()
         # rename tag


### PR DESCRIPTION
I'm working on adding tests to date/time options in watson cli commands, as a first step to improve and unify date/time handling, from which there are multiple issues reported (e.g. #75, #10).

This change has been motivated by the need to add tests for the `cli` module. In it, `watson.WatsonError` was being redefined to `WatsonCliError`, which effectively broke some existing tests in `test_watson.py` which relied on `watson.WatsonError` not being redefined.

Besides this, some `ValueError` exceptions being raised in `watson.py` have been fixed to `WatsonError` in order to be properly formatted to the user (previously, a traceback was shown).