### PR TITLE
Ignore tags and projects

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -246,9 +246,10 @@ the last full moon marking the start of the cycle.
 If you are outputting to the terminal, you can selectively enable a pager
 through the `--pager` option.
 
-You can limit the log to a project or a tag using the `--project` and
-`--tag` options. They can be specified several times each to add multiple
-projects or tags to the log.
+You can limit the log to a project or a tag using the `--project`,
+`--tag`, `--ignore-project` and `--ignore-tag` options. They can be
+specified several times each to add or ignore multiple projects or
+tags to the log.
 
 You can change the output format from *plain text* to *JSON* using the
 `--json` option or to *CSV* using the `--csv` option. Only one  of these
@@ -306,6 +307,8 @@ Flag | Help
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Logs activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Logs activity only for frames containing the given tag. You can add several tags by using this option multiple times
+`-I --ignore-project TEXT` | Logs activity for all projects but the given ones. You can ignore several projects by using the option multiple times. Any given project will be ignored
+`-i --ignore-tag TEXT` | Logs activity for all tags but the given ones. You can ignore several tags by using the option multiple times. Any given tag will be ignored
 `-j, --json` | Format output in JSON instead of plain text
 `-s, --csv` | Format output in CSV instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.
@@ -565,8 +568,8 @@ Flag | Help
 `-a, --all` | Reports all activities.
 `-p, --project TEXT` | Reports activity only for the given project. You can add other projects by using this option several times.
 `-T, --tag TEXT` | Reports activity only for frames containing the given tag. You can add several tags by using this option multiple times
-`--ignore-project TEXT` | Reports activity for all projects but the given ones. You can ignore several projects by using the option multiple times. Any given project will be ignored
-`--ignore-tag TEXT` | Reports activity for all tags but the given ones. You can ignore several tags by using the option multiple times. Any given tag will be ignored
+`-I --ignore-project TEXT` | Reports activity for all projects but the given ones. You can ignore several projects by using the option multiple times. Any given project will be ignored
+`-i --ignore-tag TEXT` | Reports activity for all tags but the given ones. You can ignore several tags by using the option multiple times. Any given tag will be ignored
 `-j, --json` | Format output in JSON instead of plain text
 `-s, --csv` | Format output in CSV instead of plain text
 `-g, --pager / -G, --no-pager` | (Don't) view output through a pager.

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -956,14 +956,18 @@ def test_add_failure(mock, watson):
                    from_date=7000, to_date=6000)
 
 
-def test_validate_report_options(mock, watson):
-    assert watson._validate_report_options(["project_foo"], None)
-    assert watson._validate_report_options(None, ["project_foo"])
-    assert not watson._validate_report_options(["project_foo"],
+def test_validate_ignore_options():
+    """
+    validate_ignore_options returns true if both list do not
+    share items
+    """
+    assert Watson.validate_ignore_options(["project_foo"], None)
+    assert Watson.validate_ignore_options(None, ["project_foo"])
+    assert not Watson.validate_ignore_options(["project_foo"],
                                                ["project_foo"])
-    assert watson._validate_report_options(["project_foo"], ["project_bar"])
-    assert not watson._validate_report_options(["project_foo", "project_bar"],
+    assert Watson.validate_ignore_options(["project_foo"], ["project_bar"])
+    assert not Watson.validate_ignore_options(["project_foo", "project_bar"],
                                                ["project_foo"])
-    assert not watson._validate_report_options(["project_foo", "project_bar"],
+    assert not Watson.validate_ignore_options(["project_foo", "project_bar"],
                                                ["project_foo", "project_bar"])
-    assert watson._validate_report_options(None, None)
+    assert Watson.validate_ignore_options(None, None)

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -194,6 +194,47 @@ def test_frames_with_empty_given_state(config_dir, mock):
     mock.patch('%s.open' % builtins, mock.mock_open(read_data=content))
     assert len(watson.frames) == 0
 
+def test_frames_filter(watson):
+    samples = (
+        ('foo', ('A')),
+        ('bar', ('A')),
+        ('foo', ('B')),
+        ('lol', ('B')),
+        ('bar', ('A'))
+    )
+    for name, tags in samples:
+        watson.frames.add(name, 4000, 4000, tags)
+
+    foo_projects = list(watson.frames.filter(projects=('foo')))
+    assert all(frame.project == 'foo' for frame in foo_projects)
+    assert len(foo_projects) == 2
+
+    not_foo_projects = list(watson.frames.filter(ignore_projects=('foo')))
+    assert all(frame.project != 'foo' for frame in not_foo_projects)
+    assert len(not_foo_projects) == 3
+
+    A_tags = list(watson.frames.filter(tags=('A')))
+    assert all(frame.tags == 'A' for frame in A_tags)
+    assert len(A_tags) == 3
+
+    not_A_tags = list(watson.frames.filter(ignore_tags=('A')))
+    assert all(frame.tags != 'A' for frame in not_A_tags)
+    assert len(not_A_tags) == 2
+
+    foo_not_A = list(watson.frames.filter(projects=('foo'), ignore_tags=('A')))
+    assert all(frame.tags != 'A' for frame in foo_not_A)
+    assert all(frame.project == 'foo' for frame in foo_not_A)
+    assert len(foo_not_A) == 1
+
+    not_foo_A = list(watson.frames.filter(ignore_projects=('foo'), tags=('A')))
+    assert all(frame.tags == 'A' for frame in not_foo_A)
+    assert all(frame.project != 'foo' for frame in not_foo_A)
+    assert len(not_foo_A) == 2
+
+    not_foo_not_A = list(watson.frames.filter(ignore_projects=('foo'), ignore_tags=('A')))
+    assert all(frame.tags != 'A' for frame in not_foo_not_A)
+    assert all(frame.project != 'foo' for frame in not_foo_not_A)
+    assert len(not_foo_not_A) == 1
 
 # config
 

--- a/watson.completion
+++ b/watson.completion
@@ -58,7 +58,7 @@ _watson_complete () {
               COMPREPLY=($(compgen -W "$tags" -- ${cur}))
               ;;
             *)
-              COMPREPLY=($(compgen -W "-a -c -C -d -f -g -G -j -m -p -t -T -w -y --all --current --no-current --pager --no-pager --from --to --project --tag --day --week --month --year --luna --json" -- ${cur})) ;;
+              COMPREPLY=($(compgen -W "-a -c -C -d -f -g -G -j -m -p -t -T -w -y -i -I --all --current --no-current --pager --no-pager --from --to --project --tag --day --week --month --year --luna --json --ignore-project --ignore-tag" -- ${cur})) ;;
           esac
           ;;
         merge)

--- a/watson.zsh-completion
+++ b/watson.zsh-completion
@@ -156,7 +156,9 @@ _watson() {
         (log|report)
           _arguments : \
             '*'{-p,--project}'[only for the given project]: :_watson_projects' \
+            '*'{-I,--ignore-project}'[all but the given project]: :_watson_projects' \
             '*'{-T,--tag}'[only for the given tag]: :_watson_tags' \
+            '*'{-i,--ignore-tag}'[all but the given tag]: :_watson_tags' \
             '(--from -f)'{-f,--from}'[start date]:date (YYYY-MM-DD):' \
             '(--to -t)'{-t,--to}'[end date]:date (YYYY-MM-DD):' \
             '(--all -a)'{-a,--all}'[output all frames]:' \

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -445,11 +445,11 @@ _SHORTCUT_OPTIONS_VALUES = {
               help="Reports activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
-@click.option('--ignore-project', 'ignore_projects', multiple=True,
+@click.option('-I', '--ignore-project', 'ignore_projects', multiple=True,
               help="Reports activity for all projects but the given ones. You "
               "can ignore several projects by using the option multiple "
               "times. Any given project will be ignored")
-@click.option('--ignore-tag', 'ignore_tags', multiple=True,
+@click.option('-i', '--ignore-tag', 'ignore_tags', multiple=True,
               help="Reports activity for all tags but the given ones. You can "
               "ignore several tags by using the option multiple times. Any "
               "given tag will be ignored")

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -872,6 +872,14 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
+@click.option('-I', '--ignore-project', 'ignore_projects', multiple=True,
+              help="Logs activity for all projects but the given ones. You "
+              "can ignore several projects by using the option multiple "
+              "times. Any given project will be ignored")
+@click.option('-i', '--ignore-tag', 'ignore_tags', multiple=True,
+              help="Logs activity for all tags but the given ones. You can "
+              "ignore several tags by using the option multiple times. Any "
+              "given tag will be ignored")
 @click.option('-j', '--json', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='json', mutually_exclusive=['csv'],
               multiple=True,
@@ -888,7 +896,7 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 def log(watson, current, from_, to, projects, tags, year, month, week, day,
-        luna, all, output_format, pager):
+        ignore_projects, ignore_tags, luna, all, output_format, pager):
     """
     Display each recorded session during the given timespan.
 
@@ -906,9 +914,10 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
     If you are outputting to the terminal, you can selectively enable a pager
     through the `--pager` option.
 
-    You can limit the log to a project or a tag using the `--project` and
-    `--tag` options. They can be specified several times each to add multiple
-    projects or tags to the log.
+    You can limit the log to a project or a tag using the `--project`,
+    `--tag`, `--ignore-project` and `--ignore-tag` options. They can be
+    specified several times each to add or ignore multiple projects or
+    tags to the log.
 
     You can change the output format from *plain text* to *JSON* using the
     `--json` option or to *CSV* using the `--csv` option. Only one  of these
@@ -967,7 +976,9 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
 
     span = watson.frames.span(from_, to)
     filtered_frames = watson.frames.filter(
-        projects=projects or None, tags=tags or None, span=span
+        projects=projects or None, tags=tags or None, span=span,
+        ignore_projects=ignore_projects or None,
+        ignore_tags=ignore_tags or None
     )
 
     if 'json' in output_format:

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -967,6 +967,14 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
     if from_ > to:
         raise click.ClickException("'from' must be anterior to 'to'")
 
+    if not _watson.Watson.validate_ignore_options(projects, ignore_projects):
+        raise click.ClickException(
+            "given projects can't be ignored at the same time")
+
+    if not _watson.Watson.validate_ignore_options(tags, ignore_tags):
+        raise click.ClickException(
+            "given tags can't be ignored at the same time")
+
     if watson.current:
         if current or (current is None and
                        watson.config.getboolean('options', 'log_current')):

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -446,7 +446,8 @@ class Watson(object):
 
         return conflicting, merging
 
-    def _validate_report_options(self, filtrate, ignored):
+    @staticmethod
+    def validate_ignore_options(filtrate, ignored):
         return not bool(
             filtrate and ignored and set(filtrate).intersection(set(ignored)))
 
@@ -457,11 +458,11 @@ class Watson(object):
                            if _ is not None):
             from_ = start_time
 
-        if not self._validate_report_options(projects, ignore_projects):
+        if not Watson.validate_ignore_options(projects, ignore_projects):
             raise WatsonError(
                 "given projects can't be ignored at the same time")
 
-        if not self._validate_report_options(tags, ignore_tags):
+        if not Watson.validate_ignore_options(tags, ignore_tags):
             raise WatsonError("given tags can't be ignored at the same time")
 
         if from_ > to:


### PR DESCRIPTION
Add -I, --ignore-project and -i, --ignore-tag options for the log command.

I preferred a Boolean option for ignoring given projects or tags (so don't have to test if --project and --ignore-project overlaps) but it was already done like that, so I kept it that way.