### PR TITLE
Enable git-like did-you-mean feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
+- Watson now suggests correct command if users make small typo (#318)
 
 ### Fixed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 arrow!=0.11,!=0.12.0
 click
 requests
+click-didyoumean

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 arrow!=0.11,!=0.12.0
 click
-requests
 click-didyoumean
+requests

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -12,6 +12,7 @@ from functools import reduce
 
 import arrow
 import click
+from click_didyoumean import DYMGroup
 
 from . import watson as _watson
 from .frames import Frame
@@ -120,7 +121,7 @@ Date = DateParamType()
 Time = TimeParamType()
 
 
-@click.group()
+@click.group(cls=DYMGroup)
 @click.version_option(version=_watson.__version__, prog_name='Watson')
 @click.pass_context
 def cli(ctx):


### PR DESCRIPTION
As watson is a command-intensive application, I think it would be a plus if it comes with did-you-mean feature powered by [click-didyoumean](https://github.com/click-contrib/click-didyoumean), e.g.
```
$ watson strat
Usage: watson [OPTIONS] COMMAND [ARGS]...
Try "watson --help" for help.
Error: No such command "strat".
Did you mean one of these?
start
status
restart
```

What do you think about this?