### PR TITLE
Allow to use fuzzed data in tests

### DIFF
--- a/scripts/fuzzer.py
+++ b/scripts/fuzzer.py
@@ -8,41 +8,52 @@ import sys
 
 from watson import Watson
 
-if not os.environ.get('WATSON_DIR'):
-    sys.exit(
-        "This script will corrupt Watson's data, please set the WATSON_DIR "
-        "environment variable to safely use it for development purpose."
-    )
-
-watson = Watson(config_dir=os.environ.get('WATSON_DIR'),
-                frames=None,
-                current=None)
-
-projects = [
+FUZZER_PROJECTS = [
     ("apollo11", ["reactor", "module", "wheels", "steering", "brakes"]),
     ("hubble", ["lens", "camera", "transmission"]),
     ("voyager1", ["probe", "generators", "sensors", "antenna"]),
     ("voyager2", ["probe", "generators", "sensors", "antenna"]),
 ]
 
-now = arrow.now()
 
-for date in arrow.Arrow.range('day', now.shift(months=-1), now):
-    if date.weekday() in (5, 6):
-        # Weekend \o/
-        continue
-
-    start = date.replace(hour=9, minute=random.randint(0, 59)) \
-                .shift(seconds=random.randint(0, 59))
-
-    while start.hour < random.randint(16, 19):
-        project, tags = random.choice(projects)
-        frame = watson.frames.add(
-            project,
-            start,
-            start.shift(seconds=random.randint(60, 4 * 60 * 60)),
-            tags=random.sample(tags, random.randint(0, len(tags)))
+def get_config_dir():
+    if len(sys.argv) == 2:
+        if not os.path.isdir(sys.argv[1]):
+            sys.exit("Invalid directory argument")
+        return sys.argv[1]
+    elif os.environ.get('WATSON_DIR'):
+        return os.environ.get('WATSON_DIR')
+    else:
+        sys.exit(
+            "This script will corrupt Watson's data, please set the WATSON_DIR"
+            " environment variable to safely use it for development purpose."
         )
-        start = frame.stop.shift(seconds=random.randint(0, 1 * 60 * 60))
 
-watson.save()
+
+def fill_watson_randomly(watson, project_data):
+    now = arrow.now()
+
+    for date in arrow.Arrow.range('day', now.shift(months=-1), now):
+        if date.weekday() in (5, 6):
+            # Weekend \o/
+            continue
+
+        start = date.replace(hour=9, minute=random.randint(0, 59)) \
+                    .shift(seconds=random.randint(0, 59))
+
+        while start.hour < random.randint(16, 19):
+            project, tags = random.choice(project_data)
+            frame = watson.frames.add(
+                project,
+                start,
+                start.shift(seconds=random.randint(60, 4 * 60 * 60)),
+                tags=random.sample(tags, random.randint(0, len(tags)))
+            )
+            start = frame.stop.shift(seconds=random.randint(0, 1 * 60 * 60))
+
+
+if __name__ == '__main__':
+    config_dir = get_config_dir()
+    watson = Watson(config_dir=config_dir, frames=None, current=None)
+    fill_watson_randomly(watson, FUZZER_PROJECTS)
+    watson.save()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 """Utility functions for the unit tests."""
 
+import os
 import datetime
 
 try:
@@ -11,6 +12,15 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
+
+import py
+
+
+TEST_FIXTURE_DIR = py.path.local(
+    os.path.dirname(
+        os.path.realpath(__file__)
+        )
+    ) / 'resources'
 
 
 def mock_datetime(dt, dt_module):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,4 +12,11 @@ def config_dir(tmpdir):
 
 @pytest.fixture
 def watson(config_dir):
+    """Creates a Watson object with an empty config directory."""
     return Watson(config_dir=config_dir)
+
+
+@pytest.fixture
+def watson_df(datafiles):
+    """Creates a Watson object with datafiles in config directory."""
+    return Watson(config_dir=str(datafiles))

--- a/tests/resources/fuzzer_data/.gitignore
+++ b/tests/resources/fuzzer_data/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -5,7 +5,6 @@ import os
 
 import arrow
 from click import get_app_dir
-import py
 import pytest
 import requests
 
@@ -13,13 +12,8 @@ from watson import Watson, WatsonError
 from watson.watson import ConfigParser, ConfigurationError
 from watson.utils import PY2
 
-from . import mock_read
+from . import mock_read, TEST_FIXTURE_DIR
 
-TEST_FIXTURE_DIR = py.path.local(
-    os.path.dirname(
-        os.path.realpath(__file__)
-        )
-    ) / 'resources'
 
 if not PY2:
     builtins = 'builtins'

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,10 @@ deps =
     mock
     pytest-datafiles
     pytest-mock
-commands = py.test -vs tests/
+commands =
+    python scripts/fuzzer.py tests/resources/fuzzer_data/
+    py.test -vs tests/
+
 usedevelop = True
 
 [testenv:flake8]


### PR DESCRIPTION
**List of changes**
- Change fuzzer.py to also support receving a path as argument where fuzzed data will be generated. Without arguments, the behavior doesn't change.
- New pytest fixture watson_df to support a non-empty config directory using pytest-datafiles. This allows to work on a copy of the original data files on each test.
- Create an empty directory where fuzzed data will be automatically generated in CI, as specified in tox.ini.
- Make TEST_FIXTURE_DIR global in the tests module, as it will be required by any test that wants to mark paths/files for pytest-datafiles.

**How to use fuzzed data in a test through the new fixture**

    @pytest.mark.datafiles(TEST_FIXTURE_DIR / 'fuzzer_data')
    def test_something(watson_df):
        pass