### PR TITLE
Use Arrows for_json for JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stylize prompt to create new project or tag (#310).
 - Aggregate calculates wrong time if used with `--current` (#293)
 - The `start` command now correctly checks if project is empty (#322)
+- The `report` and `aggregate` commands with `--json` option now correctly
+  encode Arrow objects (#329)
 
 ## [1.8.0] - 2019-08-26
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,6 +34,7 @@ from watson.utils import (
     safe_save,
     parse_tags,
     PY2,
+    json_arrow_encoder,
 )
 from . import mock_datetime
 
@@ -339,3 +340,17 @@ def test_flatten_report_for_csv(watson):
     assert result[2]['project'] == 'foo'
     assert result[2]['tag'] == 'B'
     assert result[2]['time'] == (4 + 2) * 3600
+
+
+def test_json_arrow_encoder():
+    with pytest.raises(TypeError):
+        json_arrow_encoder(0)
+
+    with pytest.raises(TypeError):
+        json_arrow_encoder('foo')
+
+    with pytest.raises(TypeError):
+        json_arrow_encoder(None)
+
+    now = arrow.utcnow()
+    assert json_arrow_encoder(now) == now.for_json()

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -31,6 +31,7 @@ from .utils import (
     sorted_groupby,
     style,
     parse_tags,
+    json_arrow_encoder,
 )
 
 
@@ -605,7 +606,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
                            luna=luna, all=all)
 
     if 'json' in output_format and not aggregated:
-        click.echo(json.dumps(report, indent=4, sort_keys=True))
+        click.echo(json.dumps(report, indent=4, sort_keys=True, default=json_arrow_encoder))
         return
     elif 'csv' in output_format and not aggregated:
         click.echo(build_csv(flatten_report_for_csv(report)))

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -606,7 +606,8 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
                            luna=luna, all=all)
 
     if 'json' in output_format and not aggregated:
-        click.echo(json.dumps(report, indent=4, sort_keys=True, default=json_arrow_encoder))
+        click.echo(json.dumps(report, indent=4, sort_keys=True,
+                              default=json_arrow_encoder))
         return
     elif 'csv' in output_format and not aggregated:
         click.echo(build_csv(flatten_report_for_csv(report)))

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -405,7 +405,8 @@ def flatten_report_for_csv(report):
 def json_arrow_encoder(obj):
     """
     Encodes Arrow objects for JSON output.
-    This function can be used with `json.dumps(..., default=json_arrow_encoder)`, for example.
+    This function can be used with
+    `json.dumps(..., default=json_arrow_encoder)`, for example.
     If the object is not an Arrow type, a TypeError is raised
     :param obj: Object to encode
     :return: JSON representation of Arrow object as defined by Arrow

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sys
 import tempfile
+from builtins import TypeError, isinstance
 try:
     from StringIO import StringIO
 except ImportError:
@@ -397,3 +398,17 @@ def flatten_report_for_csv(report):
                 'time': tag['time']
             })
     return result
+
+
+def json_arrow_encoder(obj):
+    """
+    Encodes Arrow objects for JSON output.
+    This function can be used with `json.dumps(..., default=json_arrow_encoder)`, for example.
+    If the object is not an Arrow type, a TypeError is raised
+    :param obj: Object to encode
+    :return: JSON representation of Arrow object as defined by Arrow
+    """
+    if isinstance(obj, arrow.Arrow):
+        return obj.for_json()
+
+    raise TypeError(f"Object {obj} is not JSON serializable")

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -8,7 +8,9 @@ import os
 import shutil
 import sys
 import tempfile
+
 from builtins import TypeError, isinstance
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -411,4 +413,4 @@ def json_arrow_encoder(obj):
     if isinstance(obj, arrow.Arrow):
         return obj.for_json()
 
-    raise TypeError(f"Object {obj} is not JSON serializable")
+    raise TypeError("Object {} is not JSON serializable".format(obj))

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -9,8 +9,6 @@ import shutil
 import sys
 import tempfile
 
-from builtins import TypeError, isinstance
-
 try:
     from StringIO import StringIO
 except ImportError:
@@ -25,6 +23,8 @@ from click.exceptions import UsageError
 
 PY2 = sys.version_info[0] == 2
 
+if not PY2:
+    from builtins import TypeError, isinstance
 
 try:
     text_type = (str, unicode)


### PR DESCRIPTION
Arrow provides a `for_json()` function encoding Arrow objects for JSON output.
Using the default-parameter of `json.dumps()`, this function is invoked on Arrow objects which can then be encoded for JSON output.

This PR fixes #329 