### PR TITLE
Add start and stop options to edit command

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -12,7 +12,7 @@
 Usage:  watson add [OPTIONS] [ARGS]...
 ```
 
-Add time for project with tag(s) that was not tracked live.
+Add time to a project with tag(s) that was not tracked live.
 
 Example:
 
@@ -53,7 +53,7 @@ If you are outputting to the terminal, you can selectively enable a pager
 through the `--pager` option.
 
 You can change the output format from *plain text* to *JSON* using the
-`--json` option or to *CSV* using the `--csv` option. Only one  of these
+`--json` option or to *CSV* using the `--csv` option. Only one of these
 two options can be used at once.
 
 
@@ -141,8 +141,8 @@ Usage:  watson config [OPTIONS] SECTION.OPTION [VALUE]
 
 Get and set configuration options.
 
-If value is not provided, the content of the key is displayed. Else,
-the given value is set.
+If `value` is not provided, the content of the `key` is displayed. Else,
+the given `value` is set.
 
 You can edit the config file with an editor with the `--edit` option.
 
@@ -172,12 +172,17 @@ You can specify the frame to edit by its position or by its frame id.
 For example, to edit the second-to-last frame, pass `-2` as the frame
 index. You can get the id of a frame with the `watson log` command.
 
-If no id or index is given, the frame defaults to the current frame or the
-last recorded frame, if no project is currently running.
+If no id or index is given, the frame defaults to the current frame (or the
+last recorded frame, if no project is currently running).
 
 The editor used is determined by the `VISUAL` or `EDITOR` environment
 variables (in that order) and defaults to `notepad` on Windows systems and
-to `vim`, `nano` or `vi` (first one found) on all other systems.
+to `vim`, `nano`, or `vi` (first one found) on all other systems.
+
+Alternatively, the --start and --stop parameters can be used to set the frame start and stop
+times directly from the command line (no editor will open). You have to specify the date and
+time in the format 'YYYY-MM-DD HH:mm:ss'. Trying to set the stop time for a task which is still
+in progress will raise an error.
 
 ### Options
 
@@ -185,6 +190,8 @@ Flag | Help
 -----|-----
 `-c, --confirm-new-project` | Confirm addition of new project.
 `-b, --confirm-new-tag` | Confirm creation of new tag.
+`--start DATE` | The start date and time for the project frame. Format: 'YYYY-MM-DD HH:mm:ss'
+`--stop DATE` | The stop date and time for the project frame. Format: 'YYYY-MM-DD HH:mm:ss'
 `--help` | Show this message and exit.
 
 ## `frames`
@@ -237,8 +244,8 @@ can be controlled with the `--from` and `--to` arguments. The dates
 must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
 You can also use special shortcut options for easier timespan control:
-`--day` sets the log timespan to the current day (beginning at 00:00h)
-and `--year`, `--month` and `--week` to the current year, month or week
+`--day` sets the log timespan to the current day (beginning at `00:00h`)
+and `--year`, `--month` and `--week` to the current year, month, or week,
 respectively.
 The shortcut `--luna` sets the timespan to the current moon cycle with
 the last full moon marking the start of the cycle.
@@ -251,7 +258,7 @@ You can limit the log to a project or a tag using the `--project` and
 projects or tags to the log.
 
 You can change the output format from *plain text* to *JSON* using the
-`--json` option or to *CSV* using the `--csv` option. Only one  of these
+`--json` option or to *CSV* using the `--csv` option. Only one of these
 two options can be used at once.
 
 Example:
@@ -456,8 +463,8 @@ can be controlled with the `--from` and `--to` arguments. The dates
 must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
 
 You can also use special shortcut options for easier timespan control:
-`--day` sets the report timespan to the current day (beginning at 00:00h)
-and `--year`, `--month` and `--week` to the current year, month or week
+`--day` sets the report timespan to the current day (beginning at `00:00h`)
+and `--year`, `--month` and `--week` to the current year, month, or week,
 respectively.
 The shortcut `--luna` sets the timespan to the current moon cycle with
 the last full moon marking the start of the cycle.
@@ -585,9 +592,9 @@ restarted, using the same tags as recorded in that frame. You can specify
 the frame to use with an integer frame index argument or a frame ID. For
 example, to restart the second-to-last frame, pass `-2` as the frame index.
 
-Normally, if a project is currently started, watson will print an error and
+Normally, if a project is currently started, Watson will print an error and
 do nothing. If you set the configuration option `options.stop_on_restart`
-to a true value (`1`, `on`, `true` or `yes`), the current project, if any,
+to a true value (`1`, `on`, `true`, or `yes`), the current project, if any,
 will be stopped before the new frame is started. You can pass the option
 `-s` or `--stop` resp. `-S` or `--no-stop` to override the default or
 configured behaviour.
@@ -623,10 +630,10 @@ You can add tags indicating more specifically what you are working on with
 `+tag`.
 
 If there is already a running project and the configuration option
-`options.stop_on_start` is set to a true value (`1`, `on`, `true` or
+`options.stop_on_start` is set to a true value (`1`, `on`, `true`, or
 `yes`), it is stopped before the new project is started.
 
-If the '--no-gap' flag is given, the start time of the new project is set
+If the `--no-gap` flag is given, the start time of the new project is set
 to the stop time of the most recently stopped project.
 
 Example:
@@ -685,8 +692,8 @@ Usage:  watson stop [OPTIONS]
 
 Stop monitoring time for the current project.
 
-If '--at' option is given, the provided stopping time is used. The
-specified time must be after the begin of the to be ended frame and must
+If `--at` option is given, the provided stopping time is used. The
+specified time must be after the beginning of the to-be-ended frame and must
 not be in the future.
 
 Example:

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -179,9 +179,10 @@ The editor used is determined by the `VISUAL` or `EDITOR` environment
 variables (in that order) and defaults to `notepad` on Windows systems and
 to `vim`, `nano`, or `vi` (first one found) on all other systems.
 
-Alternatively, the --start and --stop parameters can be used to set the frame start and stop
-times directly from the command line (no editor will open). Trying to set the stop time for a
-task which is still in progress will raise an error.
+Alternatively, the --start and --stop parameters can be used to set the
+frame start and stop times directly from the command line (no editor will
+open). Trying to set the stop time for a task which is still in progress
+will raise an error.
 
 Example:
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -180,9 +180,16 @@ variables (in that order) and defaults to `notepad` on Windows systems and
 to `vim`, `nano`, or `vi` (first one found) on all other systems.
 
 Alternatively, the --start and --stop parameters can be used to set the frame start and stop
-times directly from the command line (no editor will open). You have to specify the date and
-time in the format 'YYYY-MM-DD HH:mm:ss'. Trying to set the stop time for a task which is still
-in progress will raise an error.
+times directly from the command line (no editor will open). Trying to set the stop time for a
+task which is still in progress will raise an error.
+
+Example:
+
+
+    $ watson edit --start 13:30 --stop 14:00
+    Edited frame for project misc, from 13:30:00 to 14:00:00 (30m 00s)
+    $ watson edit --start 2019-10-27T13:30 --stop 14:00
+    Edited frame for project misc, from 13:30:00 to 14:00:00 (24h 30m 00s)
 
 ### Options
 
@@ -190,8 +197,8 @@ Flag | Help
 -----|-----
 `-c, --confirm-new-project` | Confirm addition of new project.
 `-b, --confirm-new-tag` | Confirm creation of new tag.
-`--start DATE` | The start date and time for the project frame. Format: 'YYYY-MM-DD HH:mm:ss'
-`--stop DATE` | The stop date and time for the project frame. Format: 'YYYY-MM-DD HH:mm:ss'
+`--start TIME` | The start time for the project frame.
+`--stop TIME` | The stop time for the project frame.
 `--help` | Show this message and exit.
 
 ## `frames`

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1205,6 +1205,11 @@ def edit(watson, confirm_new_project, confirm_new_tag, id, start=None, stop=None
     The editor used is determined by the `VISUAL` or `EDITOR` environment
     variables (in that order) and defaults to `notepad` on Windows systems and
     to `vim`, `nano`, or `vi` (first one found) on all other systems.
+
+    Alternatively, the --start and --stop parameters can be used to set the frame start and stop
+    times directly from the command line (no editor will open). You have to specify the date and
+    time in the format 'YYYY-MM-DD HH:mm:ss'. Trying to set the stop time for a task which is still
+    in progress will raise an error.
     """
     date_format = 'YYYY-MM-DD'
     time_format = 'HH:mm:ss'

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1184,8 +1184,10 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
               help="Confirm addition of new project.")
 @click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
               help="Confirm creation of new tag.")
-@click.option('--start', type=Time, default=None, help="The start time for the project frame.")
-@click.option('--stop', type=Time, default=None, help="The stop time for the project frame.")
+@click.option('--start', type=Time, default=None, help='The start time for '
+              'the project frame.')
+@click.option('--stop', type=Time, default=None, help='The stop time for the '
+              'project frame.')
 @click.argument('id', required=False)
 @click.pass_obj
 @catch_watson_error
@@ -1204,9 +1206,10 @@ def edit(watson, confirm_new_project, confirm_new_tag, id, start, stop):
     variables (in that order) and defaults to `notepad` on Windows systems and
     to `vim`, `nano`, or `vi` (first one found) on all other systems.
 
-    Alternatively, the --start and --stop parameters can be used to set the frame start and stop
-    times directly from the command line (no editor will open). Trying to set the stop time for a
-    task which is still in progress will raise an error.
+    Alternatively, the --start and --stop parameters can be used to set the
+    frame start and stop times directly from the command line (no editor will
+    open). Trying to set the stop time for a task which is still in progress
+    will raise an error.
 
     Example:
 
@@ -1243,7 +1246,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, id, start, stop):
 
         if stop and watson.is_started:
             raise click.ClickException(
-                style('error', "Cannot set stop time for task which is still running."))
+                style('error', "Cannot set stop time for task which is still "
+                      "running."))
 
         if not stop and id:
             stop = frame.stop
@@ -1284,13 +1288,15 @@ def edit(watson, confirm_new_project, confirm_new_tag, id, start, stop):
                 data = json.loads(output)
                 project = data['project']
                 # Confirm creation of new project if that option is set
-                if (watson.config.getboolean('options', 'confirm_new_project') or
-                        confirm_new_project):
+                opt_confirm_new_project = watson.config.getboolean('options',
+                   'confirm_new_project')
+                if (opt_confirm_new_project or confirm_new_project):
                     confirm_project(project, watson.projects)
                 tags = data['tags']
                 # Confirm creation of new tag(s) if that option is set
-                if (watson.config.getboolean('options', 'confirm_new_tag') or
-                        confirm_new_tag):
+                opt_confirm_new_tag = watson.config.getboolean('options',
+                    'confirm_new_tag')
+                if (opt_confirm_new_tag or confirm_new_tag):
                     confirm_tags(tags, watson.tags)
                 start = arrow.get(data['start'], datetime_format).replace(
                     tzinfo=local_tz).to('utc')
@@ -1305,8 +1311,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, id, start, stop):
                 #  the edit function normally
                 break
             except (ValueError, TypeError, RuntimeError) as e:
-                click.echo(u"Error while parsing inputted values: {}".format(e),
-                           err=True)
+                err_msg = u"Error while parsing inputted values: {}".format(e)
+                click.echo(err_msg, err=True)
             except KeyError:
                 click.echo(
                     "The edited frame must contain the project, "

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1184,14 +1184,12 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
               help="Confirm addition of new project.")
 @click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
               help="Confirm creation of new tag.")
-@click.option('--start', type=Date, help="The start date and time for the project frame. "
-              "Format: 'YYYY-MM-DD HH:mm:ss'")
-@click.option('--stop', type=Date, help="The stop date and time for the project frame. "
-              "Format: 'YYYY-MM-DD HH:mm:ss'")
+@click.option('--start', type=Time, default=None, help="The start time for the project frame.")
+@click.option('--stop', type=Time, default=None, help="The stop time for the project frame.")
 @click.argument('id', required=False)
 @click.pass_obj
 @catch_watson_error
-def edit(watson, confirm_new_project, confirm_new_tag, id, start=None, stop=None):
+def edit(watson, confirm_new_project, confirm_new_tag, id, start, stop):
     """
     Edit a frame.
 
@@ -1207,9 +1205,16 @@ def edit(watson, confirm_new_project, confirm_new_tag, id, start=None, stop=None
     to `vim`, `nano`, or `vi` (first one found) on all other systems.
 
     Alternatively, the --start and --stop parameters can be used to set the frame start and stop
-    times directly from the command line (no editor will open). You have to specify the date and
-    time in the format 'YYYY-MM-DD HH:mm:ss'. Trying to set the stop time for a task which is still
-    in progress will raise an error.
+    times directly from the command line (no editor will open). Trying to set the stop time for a
+    task which is still in progress will raise an error.
+
+    Example:
+
+    \b
+    $ watson edit --start 13:30 --stop 14:00
+    Edited frame for project misc, from 13:30:00 to 14:00:00 (30m 00s)
+    $ watson edit --start 2019-10-27T13:30 --stop 14:00
+    Edited frame for project misc, from 13:30:00 to 14:00:00 (24h 30m 00s)
     """
     date_format = 'YYYY-MM-DD'
     time_format = 'HH:mm:ss'


### PR DESCRIPTION
As mentioned in #309, it's sometimes convenient to edit the start or stop times of a frame without opening an editor, so this PR adds two parameters to the `watson edit` command:
- `--start` sets the start time for a frame
- `--stop` sets the stop time for a frame

I chose the names "start" and "stop" rather than "from" and "to" since it matches the json shown in in the editor (and the names watson uses with frames internally).

Example usage:
```
watson edit --start "2019-10-27T14:30:00" --stop "2019-10-27T15:00:00"
watson edit --start "14:30" --stop "15:00"
watson edit --start "14:30" 
watson edit -2 --stop "15:00"
```

I rebuild the docs since the docstring and parameters for `edit` had changed, and it seems like a few other pending changes to the docs were also included (looks like mainly punctuation), so sorry if that causes any confusion. 

### TODO

**Update**: I've updated the PR to use TimeParamType instead which is a bit easier to use, so the comments below are obsolete. I found the `stop --at` command which already uses this syntax so it's also more consistent to use the same here. 

I'd quite like to be able to specify just a time on the command line, since typing the date is a bit of a hassle and is usually not needed since we could use the current date or keep the date the frame has unchanged. However for now I've used the DateParamType, which means we have to specify date and time. Using TimeParamType instead would mostly do what I was hoping as the user could choose either a time only or a time with date. But I'm not sure if the format is the most convenient: TimeParamType won't recognize spaces between the date and time ("2019-10-27 15:00:00"); it needs the letter "T" between them ("2019-10-27T15:00:00"). I had a quick search to see if TimeParamType was used elsewhere but couldn't find any other usages, so I'm not really sure if there's any existing precedent for this. I'd be grateful if anyone has any advice!