### PR TITLE
Allow to force enable/disable colored output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log output order can now be controlled via the `--reverse/--no-reverse` flag
   and the `reverse_log` configuration option (#369)
 - Add `--at` flag to the `start` and `restart` commands (#364).
+- Add `--color` and `--no-color` flags to force output to be colored or not
+  respectively (#350).
 
 ### Changed
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -127,8 +127,10 @@ def catch_watson_error(func):
 
 @click.group(cls=DYMGroup)
 @click.version_option(version=_watson.__version__, prog_name='Watson')
+@click.option('--color/--no-color', 'color', default=None,
+              help="(Don't) color output.")
 @click.pass_context
-def cli(ctx):
+def cli(ctx, color):
     """
     Watson is a tool aimed at helping you monitoring your time.
 
@@ -136,6 +138,9 @@ def cli(ctx):
     project with the `start` command, and you can stop the timer
     when you're done with the `stop` command.
     """
+
+    if color is not None:
+        ctx.color = True if color else False
 
     # This is the main command group, needed by click in order
     # to handle the subcommands


### PR DESCRIPTION
Hello!

In most cases click library figures out correctly if colored output should be used, but sometimes it's wrong. For example when `watch` command is used click is unable to determine this and chooses uncolored output:
```
watch --color 'watson aggregate'
```

This change allows user to explicitly enable/disable coloring with `--color` and `--no-color` options:
```
 watch --color 'watson --color aggregate'
```

Related issue: pallets/click#1090