### PR TITLE
Add optional interactive shell through click-repl

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,11 @@ On OS X, the easiest way to install Watson is using [Homebrew](http://brew.sh/):
 ```bash
 $ brew update && brew install watson
 ```
+### Optional interactive shell
+
+If you install [`click-repl`](https://github.com/untitaker/click-repl), watson
+gets a new command called ``repl``, which launches an interactive shell with
+tab-completion.
 
 ### Distribution packages
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,11 @@ setup(
     long_description=readme,
     install_requires=parse_requirements('requirements.txt'),
     tests_require=parse_requirements('requirements-dev.txt'),
+    extras_require={
+        'repl': [
+            'click-repl>=0.1.6',
+        ]
+    },
     entry_points={
         'console_scripts': [
             'watson = watson.__main__:cli',

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -142,6 +142,14 @@ def cli(ctx):
     ctx.obj = create_watson()
 
 
+try:  # pragma: no cover
+    import click_repl
+    click_repl.register_repl(cli)
+    click_repl.register_repl(cli, name="shell")
+except ImportError:
+    pass
+
+
 @cli.command()
 @click.argument('command', required=False)
 @click.pass_context


### PR DESCRIPTION
By installing `click-repl`[0] the user gets an interactive shell with
tab completion enabled.

[0]: https://github.com/untitaker/click-repl