### PR TITLE
Fix usage-info in 'help' command

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,7 +95,7 @@ def test_show_command_help(runner, watson, cmd_name):
     result = runner.invoke(
          cli.help,
          [cmd_name],
-        obj=watson)
+         obj=watson)
     assert result.exit_code == 0
     assert result.output.startswith('Usage: ' + cmd_name)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,18 @@ class OutputParser:
         return watson.frames[frame_id].start.format('YYYY-MM-DD HH:mm:ss')
 
 
+# watson help
+
+@pytest.mark.parametrize('cmd_name', ['add', 'start', 'stop'])
+def test_show_command_help(runner, watson, cmd_name):
+    result = runner.invoke(
+         cli.help,
+         [cmd_name],
+        obj=watson)
+    assert result.exit_code == 0
+    assert result.output.startswith('Usage: ' + cmd_name)
+
+
 # watson add
 
 @pytest.mark.parametrize('test_dt,expected', VALID_DATES_DATA)

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -158,7 +158,10 @@ def help(ctx, command):
     if not cmd:
         raise click.ClickException(u"No such command: {}".format(command))
 
-    click.echo(cmd.get_help(ctx))
+    # the passed context is that of the 'help' command, which would
+    # show up in the Usage: ... - message. Create the proper context:
+    cmd_context = click.Context(cmd, parent=ctx.parent, info_name=cmd.name)
+    click.echo(cmd.get_help(cmd_context))
 
 
 def _start(watson, project, tags, restart=False, gap=True):


### PR DESCRIPTION
Typing 'watson help start' would have printed 'Usage: watson help [OPTIONS]...'
instead of 'Usage: watson start [OPTIONS]...'.