### PR TITLE
Allow specification of start time via `start_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
 - Watson now suggests correct command if users make small typo (#318)
-- Log output order can now be controlled via the `--reverse/--no-reverse` flag
-  and the `reverse_log` configuration option (#369)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Log output order can now be controlled via the `--reverse/--no-reverse` flag
   and the `reverse_log` configuration option (#369)
+- Add `--at` flag to the `start` and `restart` commands (#364).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
 - Watson now suggests correct command if users make small typo (#318)
+- Log output order can now be controlled via the `--reverse/--no-reverse` flag
+  and the `reverse_log` configuration option (#369)
 
 ### Changed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,3 +182,11 @@ def test_stop_valid_time(runner, watson, mocker, at_dt):
     arrow.arrow.datetime.now.return_value = (start_dt + timedelta(hours=1))
     result = runner.invoke(cli.stop, ['--at', at_dt], obj=watson)
     assert result.exit_code == 0
+
+
+# watson start
+
+@pytest.mark.parametrize('at_dt', VALID_TIMES_DATA)
+def test_start_valid_time(runner, watson, mocker, at_dt):
+    result = runner.invoke(cli.start, ['a-project', '--at', at_dt], obj=watson)
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,5 +188,9 @@ def test_stop_valid_time(runner, watson, mocker, at_dt):
 
 @pytest.mark.parametrize('at_dt', VALID_TIMES_DATA)
 def test_start_valid_time(runner, watson, mocker, at_dt):
+    # Simulate a start date so that 'at_dt' is older than now().
+    mocker.patch('arrow.arrow.datetime', wraps=datetime)
+    start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=tzlocal())
+    arrow.arrow.datetime.now.return_value = (start_dt + timedelta(hours=1))
     result = runner.invoke(cli.start, ['a-project', '--at', at_dt], obj=watson)
     assert result.exit_code == 0

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -635,14 +635,14 @@ def test_pull(mocker, watson):
                 {
                     'id': '1c006c6e-6cc1-4c80-ab22-b51c857c0b06',
                     'project': 'foo',
-                    'start_at': 4003,
+                    'begin_at': 4003,
                     'end_at': 4004,
                     'tags': ['A']
                 },
                 {
                     'id': 'c44aa815-4d77-4a58-bddd-1afa95562141',
                     'project': 'bar',
-                    'start_at': 4004,
+                    'begin_at': 4004,
                     'end_at': 4005,
                     'tags': []
                 }

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -279,13 +279,13 @@ def test_start_project_at(watson):
     watson.start('foo', start_at=now)
     watson.stop()
 
-    # Can't start before the previous task ends
+    # Task can't start before the previous task ends
     with pytest.raises(WatsonError):
         time_str = '1970-01-01T00:00'
         time_obj = arrow.get(time_str)
         watson.start('foo', start_at=time_obj)
 
-    # Can't start in the future
+    # Task can't start in the future
     with pytest.raises(WatsonError):
         time_str = '2999-12-31T23:59'
         time_obj = arrow.get(time_str)

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -331,13 +331,15 @@ def test_stop_started_project_at(watson):
     watson.start('foo')
     now = arrow.now()
 
+    # Task can't end before it starts
     with pytest.raises(WatsonError):
         time_str = '1970-01-01T00:00'
         time_obj = arrow.get(time_str)
         watson.stop(stop_at=time_obj)
 
-    with pytest.raises(ValueError):
-        time_str = '2999-31-12T23:59'
+    # Task can't end in the future
+    with pytest.raises(WatsonError):
+        time_str = '2999-12-31T23:59'
         time_obj = arrow.get(time_str)
         watson.stop(stop_at=time_obj)
 

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -274,6 +274,26 @@ def test_start_nogap(watson):
     assert watson.frames[-1].stop == watson.current['start']
 
 
+def test_start_project_at(watson):
+    now = arrow.now()
+    watson.start('foo', start_at=now)
+    watson.stop()
+
+    # Can't start before the previous task ends
+    with pytest.raises(WatsonError):
+        time_str = '1970-01-01T00:00'
+        time_obj = arrow.get(time_str)
+        watson.start('foo', start_at=time_obj)
+
+    # Can't start in the future
+    with pytest.raises(WatsonError):
+        time_str = '2999-12-31T23:59'
+        time_obj = arrow.get(time_str)
+        watson.start('foo', start_at=time_obj)
+
+    assert watson.frames[-1].start == now
+
+
 # stop
 
 def test_stop_started_project(watson):

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1007,7 +1007,7 @@ def log(watson, current, reverse, from_, to, projects, tags, year, month, week,
     frames_by_day = sorted_groupby(
         filtered_frames,
         operator.attrgetter('day'),
-        reverse=reverse
+        reverse=watson.config.getboolean('options', 'reverse_log', True)
     )
 
     lines = []

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -193,7 +193,8 @@ def _start(watson, project, tags, restart=False, start_at=None, gap=True):
 @click.pass_obj
 @click.pass_context
 @catch_watson_error
-def start(ctx, watson, confirm_new_project, confirm_new_tag, args, at_, gap_=True):
+def start(ctx, watson, confirm_new_project, confirm_new_tag, args, at_,
+          gap_=True):
     """
     Start monitoring time for the given project.
     You can add tags indicating more specifically what you are working on with

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1007,7 +1007,7 @@ def log(watson, current, reverse, from_, to, projects, tags, year, month, week,
     frames_by_day = sorted_groupby(
         filtered_frames,
         operator.attrgetter('day'),
-        reverse=watson.config.getboolean('options', 'reverse_log', True)
+        reverse=reverse
     )
 
     lines = []

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -177,9 +177,11 @@ def _start(watson, project, tags, restart=False, start_at=None, gap=True):
 
 @cli.command()
 @click.option('--at', 'at_', type=DateTime, default=None,
+              cls=MutuallyExclusiveOption, mutually_exclusive=['gap_'],
               help=('Start frame at this time. Must be in '
                     '(YYYY-MM-DDT)?HH:MM(:SS)? format.'))
 @click.option('-g/-G', '--gap/--no-gap', 'gap_', is_flag=True, default=True,
+              cls=MutuallyExclusiveOption, mutually_exclusive=['at_'],
               help=("(Don't) leave gap between end time of previous project "
                     "and start time of the current."))
 @click.argument('args', nargs=-1,

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -161,11 +161,12 @@ def help(ctx, command):
     click.echo(cmd.get_help(ctx))
 
 
-def _start(watson, project, tags, restart=False, gap=True):
+def _start(watson, project, tags, restart=False, start_at=None, gap=True):
     """
     Start project with given list of tags and save status.
     """
-    current = watson.start(project, tags, restart=restart, gap=gap)
+    current = watson.start(project, tags, restart=restart, start_at=start_at,
+                           gap=gap,)
     click.echo(u"Starting project {}{} at {}".format(
         style('project', project),
         (" " if current['tags'] else "") + style('tags', current['tags']),
@@ -175,6 +176,9 @@ def _start(watson, project, tags, restart=False, gap=True):
 
 
 @cli.command()
+@click.option('--at', 'at_', type=DateTime, default=None,
+              help=('Start frame at this time. Must be in '
+                    '(YYYY-MM-DDT)?HH:MM(:SS)? format.'))
 @click.option('-g/-G', '--gap/--no-gap', 'gap_', is_flag=True, default=True,
               help=("(Don't) leave gap between end time of previous project "
                     "and start time of the current."))
@@ -187,7 +191,7 @@ def _start(watson, project, tags, restart=False, gap=True):
 @click.pass_obj
 @click.pass_context
 @catch_watson_error
-def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
+def start(ctx, watson, confirm_new_project, confirm_new_tag, args, at_, gap_=True):
     """
     Start monitoring time for the given project.
     You can add tags indicating more specifically what you are working on with
@@ -196,6 +200,16 @@ def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
     If there is already a running project and the configuration option
     `options.stop_on_start` is set to a true value (`1`, `on`, `true`, or
     `yes`), it is stopped before the new project is started.
+
+    If `--at` option is given, the provided starting time is used. The
+    specified time must be after the end of the previous frame and must not be
+    in the future.
+
+    Example:
+
+    \b
+    $ watson start --at 13:37
+    Starting project apollo11 at 13:37
 
     If the `--no-gap` flag is given, the start time of the new project is set
     to the stop time of the most recently stopped project.
@@ -239,7 +253,7 @@ def start(ctx, watson, confirm_new_project, confirm_new_tag, args, gap_=True):
             watson.config.getboolean('options', 'stop_on_start')):
         ctx.invoke(stop)
 
-    _start(watson, project, tags, gap=gap_)
+    _start(watson, project, tags, start_at=at_, gap=gap_)
 
 
 @cli.command(context_settings={'ignore_unknown_options': True})

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -289,13 +289,16 @@ def stop(watson, at_):
 
 
 @cli.command(context_settings={'ignore_unknown_options': True})
+@click.option('--at', 'at_', type=DateTime, default=None,
+              help=('Start frame at this time. Must be in '
+                    '(YYYY-MM-DDT)?HH:MM(:SS)? format.'))
 @click.option('-s/-S', '--stop/--no-stop', 'stop_', default=None,
               help="(Don't) Stop an already running project.")
 @click.argument('frame', default='-1', autocompletion=get_frames)
 @click.pass_obj
 @click.pass_context
 @catch_watson_error
-def restart(ctx, watson, frame, stop_):
+def restart(ctx, watson, frame, stop_, at_):
     """
     Restart monitoring time for a previously stopped project.
 
@@ -343,7 +346,7 @@ def restart(ctx, watson, frame, stop_):
 
     frame = get_frame_from_argument(watson, frame)
 
-    _start(watson, frame.project, frame.tags, restart=True)
+    _start(watson, frame.project, frame.tags, restart=True, start_at=at_)
 
 
 @cli.command()

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -252,11 +252,6 @@ class Watson(object):
         return frame
 
     def start(self, project, tags=None, restart=False, start_at=None, gap=True):
-        if start_at is not None and not gap:
-            raise WatsonError(
-                'gap=False species the start time to be the end of the '
-                'previous block, so you cannot use it in conjunction with '
-                'start_at.')
         if self.is_started:
             raise WatsonError(
                 u"Project {} is already started.".format(

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -255,7 +255,7 @@ class Watson(object):
         if start_at is not None and not gap:
             raise WatsonError(
                 'gap=False species the start time to be the end of the '
-                'previoys block, so you cannot use it in conjunction with '
+                'previous block, so you cannot use it in conjunction with '
                 'start_at.')
         if self.is_started:
             raise WatsonError(

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -266,16 +266,19 @@ class Watson(object):
 
         if start_at is None:
             start_at = arrow.now()
+        else:
+            # Only perform this check if an explicit start time was given
+            stop_of_prev_frame = self.frames[-1].stop
+            if start_at < stop_of_prev_frame:
+                raise WatsonError('Task cannot start before the previous task '
+                                  'ends.')
         if start_at > arrow.now():
             raise WatsonError('Task cannot start in the future.')
-        stop_of_prev_frame = self.frames[-1].stop
-        if start_at < stop_of_prev_frame:
-            raise WatsonError('Task cannot start before previous task ended.')
 
         new_frame = {'project': project, 'tags': deduplicate(tags)}
         new_frame['start'] = start_at
-
         if not gap:
+            stop_of_prev_frame = self.frames[-1].stop
             new_frame['start'] = stop_of_prev_frame
         self.current = new_frame
         return self.current

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -399,7 +399,7 @@ class Watson(object):
             frame_id = uuid.UUID(frame['id']).hex
             self.frames[frame_id] = (
                 frame['project'],
-                frame['start_at'],
+                frame['begin_at'],
                 frame['end_at'],
                 frame['tags']
             )
@@ -416,7 +416,7 @@ class Watson(object):
             if last_pull > frame.updated_at > self.last_sync:
                 frames.append({
                     'id': uuid.UUID(frame.id).urn,
-                    'start_at': str(frame.start.to('utc')),
+                    'begin_at': str(frame.start.to('utc')),
                     'end_at': str(frame.stop.to('utc')),
                     'project': frame.project,
                     'tags': frame.tags

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -266,8 +266,9 @@ class Watson(object):
 
         if start_at is None:
             start_at = arrow.now()
-        else:
+        elif self.frames:
             # Only perform this check if an explicit start time was given
+            # and previous frames exist
             stop_of_prev_frame = self.frames[-1].stop
             if start_at < stop_of_prev_frame:
                 raise WatsonError('Task cannot start before the previous task '

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -251,7 +251,8 @@ class Watson(object):
         frame = self.frames.add(project, from_date, to_date, tags=tags)
         return frame
 
-    def start(self, project, tags=None, restart=False, start_at=None, gap=True):
+    def start(self, project, tags=None, restart=False, start_at=None,
+              gap=True):
         if self.is_started:
             raise WatsonError(
                 u"Project {} is already started.".format(


### PR DESCRIPTION
A suggestion for how to implement `start_at` similar to the already existing `stop_at`. @jmaupetit 

Note that there are 11 tests failing for me on the master branch, which is unchanged with the additions suggested here.

Close  #75 #224 #352