### PR TITLE
Avoid dubble newlines in csv output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Always show total time at bottom of report (#356)
+- Use the default system newline character for CSV output.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Always show total time at bottom of report (#356)
-- Use the default system newline character for CSV output.
+- Use the default system newline character for CSV output (#366).
 
 ### Fixed
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,14 +245,14 @@ def test_build_csv_empty_data():
 
 
 def test_build_csv_one_col():
-    lt = csv.get_dialect('excel').lineterminator
+    lt = os.linesep
     data = [{'col': 'value'}, {'col': 'another value'}]
     result = lt.join(['col', 'value', 'another value']) + lt
     assert build_csv(data) == result
 
 
 def test_build_csv_multiple_cols():
-    lt = csv.get_dialect('excel').lineterminator
+    lt = os.linesep
     dm = csv.get_dialect('excel').delimiter
     data = [
         co.OrderedDict([('col1', 'value'),

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -358,7 +358,7 @@ def build_csv(entries):
     else:
         return ''
     memfile = StringIO()
-    writer = csv.DictWriter(memfile, header)
+    writer = csv.DictWriter(memfile, header, lineterminator=os.linesep)
     writer.writeheader()
     writer.writerows(entries)
     output = memfile.getvalue()


### PR DESCRIPTION
I noticed that an extra newline character is added to each line of the `--csv` outputs
(displayed as `^M` in vim):

```text
id,start,stop,project,tags^M
76575e4,2020-04-22 19:48:43,2020-04-22 21:15:51,tweaks,optimization^M
128fb31,2020-04-22 21:18:24,2020-04-22 23:19:26,test-proj,"tag1, tag2"^M
```

This is not needed and can cause some programs to accidentally read in a blank line between each line in the csv output:


```text
id,start,stop,project,tags

76575e4,2020-04-22 19:48:43,2020-04-22 21:15:51,tweaks,optimization

128fb31,2020-04-22 21:18:24,2020-04-22 23:19:26,test-proj,"tag1, tag2"
```

This PR is a suggestion for how to fix this and change the output of `--csv` to

```text
id,start,stop,project,tags
76575e4,2020-04-22 19:48:43,2020-04-22 21:15:51,tweaks,optimization
128fb31,2020-04-22 21:18:24,2020-04-22 23:19:26,test-proj,"tag1, tag2"
```

I have only tested this in vim and gedit on Linux.