### PR TITLE
Add option to control the order of the days in the `log` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Log output order can now be controlled via the `--reverse/--no-reverse` flag
+  and the `reverse_log` configuration option (#369)
+
 ### Changed
 
 - Require latest Arrow version 0.15.6 to support ISO week dates (#380)
@@ -17,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
 - Watson now suggests correct command if users make small typo (#318)
-- Log output order can now be controlled via the `--reverse/--no-reverse` flag
-  and the `reverse_log` configuration option (#369)
 
 ### Changed
 
@@ -30,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stylize prompt to create new project or tag (#310).
 - Aggregate calculates wrong time if used with `--current` (#293)
 - The `start` command now correctly checks if project is empty (#322)
-- Aggregate ignores frames that crosses aggreagate boundary (#248)
+- Aggregate ignores frames that crosses aggregate boundary (#248)
 - The `report` and `aggregate` commands with `--json` option now correctly
   encode Arrow objects (#329)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve Arrow 0.15.0 support after changes in `arrow.get()` behavior (#296)
 - Watson now suggests correct command if users make small typo (#318)
+- Log output order can now be controlled via the `--reverse/--no-reverse` flag
+  and the `reverse_log` configuration option (#369)
 
 ### Changed
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -129,6 +129,12 @@ If `true`, the output of the `report` command will include the currently
 running frame (if any) by default. The option can be overridden on the
 command line with the `-c/-C` resp. `--current/--no-current` flags.
 
+#### `options.reverse_log` (default: `true`)
+
+If `true`, the output of the `log` command will reverse the order of the days
+to display the latest day's entries on top and the oldest day's entries at the
+bottom.
+
 #### `options.stop_on_start` (default: `false`)
 
 If `true`, starting a new project will stop running projects:
@@ -230,6 +236,7 @@ week_start = monday
 log_current = false
 pager = true
 report_current = false
+reverse_log = true
 ```
 
 ## Application folder

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -133,7 +133,8 @@ command line with the `-c/-C` resp. `--current/--no-current` flags.
 
 If `true`, the output of the `log` command will reverse the order of the days
 to display the latest day's entries on top and the oldest day's entries at the
-bottom.
+bottom. The option can be overridden on the command line with the `-r/-R` resp.
+`--reverse/--no-reverse` flags.
 
 #### `options.stop_on_start` (default: `false`)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import functools
 import json
 import os
 import datetime
+import operator
 
 try:
     from StringIO import StringIO
@@ -32,6 +33,7 @@ from watson.utils import (
     get_start_time_for_period,
     make_json_writer,
     safe_save,
+    sorted_groupby,
     parse_tags,
     PY2,
     json_arrow_encoder,
@@ -268,6 +270,32 @@ def test_build_csv_multiple_cols():
         dm.join(['one value', 'two value', 'three'])
         ]) + lt
     assert build_csv(data) == result
+
+
+# sorted_groupby
+
+def test_sorted_groupby(watson):
+    end = arrow.utcnow()
+    watson.add('foo', end.shift(hours=-25), end.shift(hours=-24), ['A'])
+    watson.add('bar', end.shift(hours=-1), end, ['A'])
+
+    result = list(sorted_groupby(
+        watson.frames,
+        operator.attrgetter('day'),
+        reverse=False))
+    assert result[0][0] < result[1][0]
+
+
+def test_sorted_groupby_reverse(watson):
+    end = arrow.utcnow()
+    watson.add('foo', end.shift(hours=-25), end.shift(hours=-24), ['A'])
+    watson.add('bar', end.shift(hours=-1), end, ['A'])
+
+    result = list(sorted_groupby(
+        watson.frames,
+        operator.attrgetter('day'),
+        reverse=True))
+    assert result[0][0] > result[1][0]
 
 
 # frames_to_csv

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -853,6 +853,8 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
 @cli.command()
 @click.option('-c/-C', '--current/--no-current', 'current', default=None,
               help="(Don't) include currently running frame in output.")
+@click.option('-r/-R', '--reverse/--no-reverse', 'reverse', default=None,
+              help="(Don't) reverse the order of the days in output.")
 @click.option('-f', '--from', 'from_', type=DateTime,
               default=arrow.now().shift(days=-7),
               help="The date from when the log should start. Defaults "
@@ -908,8 +910,8 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
               help="(Don't) view output through a pager.")
 @click.pass_obj
 @catch_watson_error
-def log(watson, current, from_, to, projects, tags, year, month, week, day,
-        luna, all, output_format, pager):
+def log(watson, current, reverse, from_, to, projects, tags, year, month, week,
+        day, luna, all, output_format, pager):
     """
     Display each recorded session during the given timespan.
 
@@ -986,6 +988,9 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
             watson.frames.add(cur['project'], cur['start'], arrow.utcnow(),
                               cur['tags'], id="current")
 
+    if reverse is None:
+        reverse = watson.config.getboolean('options', 'reverse_log', True)
+
     span = watson.frames.span(from_, to)
     filtered_frames = watson.frames.filter(
         projects=projects or None, tags=tags or None, span=span
@@ -1002,7 +1007,7 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
     frames_by_day = sorted_groupby(
         filtered_frames,
         operator.attrgetter('day'),
-        reverse=watson.config.getboolean('options', 'reverse_log', True)
+        reverse=reverse
     )
 
     lines = []

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1001,7 +1001,8 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
 
     frames_by_day = sorted_groupby(
         filtered_frames,
-        operator.attrgetter('day'), reverse=True
+        operator.attrgetter('day'),
+        reverse=watson.config.getboolean('options', 'reverse_log', True)
     )
 
     lines = []


### PR DESCRIPTION
I think it is quite common to sort with the newest entry at the bottom (e.g with `ls` and this is also how the times are ordering within each day in the `log` output), so I suggest adding an option to enable this behavior.