### PR TITLE
Limit arrow version to under 0.15.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow!=0.11,!=0.12.0
+arrow!=0.11,!=0.12.0,<0.15.6
 click
 click-didyoumean
 requests


### PR DESCRIPTION
Version 0.15.6 of `arrow` support iso week formats https://arrow.readthedocs.io/en/latest/releases.html. Eventually some of the docs and tests of watson could be rewritten to reflect this change, but until that is done, I suggest to pin the version of `arrow` to avoid that tests fail on new PRs (and having to maintain different test cases for the different arrow versions).