### PR TITLE
[Requirements] add colorama for Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 arrow!=0.11,!=0.12.0,<0.15.6
 click
 click-didyoumean
+colorama; sys_platform == "win32"
 requests

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1047,7 +1047,6 @@ def log(watson, current, from_, to, projects, tags, year, month, week, day,
                 project=style('project', u'{:>{}}'.format(
                     frame.project, longest_project
                 )),
-                pad=longest_project,
                 tags=(" "*2 if frame.tags else "") + style('tags', frame.tags),
                 start=style('time', '{:HH:mm}'.format(frame.start)),
                 stop=style('time', '{:HH:mm}'.format(frame.stop)),


### PR DESCRIPTION
Click seems to have built-in color support, but this only kicks on Windows if `colorama` is also installed.

The PR adds colorama to the requirements for Windows only to turn on color support.