### PR TITLE
Add after edit check that start is in the past, closes #381

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require latest Arrow version 0.15.6 to support ISO week dates (#380)
 
+### Fixed
+
+- Make after-edit-check ensure that edited time stamps are not in the future
+  (#381)
+
+
 ## [1.9.0] - 2020-05-27
 
 ### Added

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1297,6 +1297,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
                     "Task cannot end before it starts.")
             if start > arrow.utcnow():
                 raise ValueError("Start time cannot be in the future")
+            if stop and stop > arrow.utcnow():
+                raise ValueError("Stop time cannot be in the future")
             # break out of while loop and continue execution of
             #  the edit function normally
             break

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1295,6 +1295,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
             if not watson.is_started and start > stop:
                 raise ValueError(
                     "Task cannot end before it starts.")
+            if start > arrow.utcnow():
+                raise ValueError("Start time cannot be in the future")
             # break out of while loop and continue execution of
             #  the edit function normally
             break


### PR DESCRIPTION
This PR adds an after edit check that checks whether the start time is in the past. The PR was triggered by myself accidentally doing this during an edit of the current task and noticing that I didn't get an error before stopping the task, which is mildly confusing.

However. This PR raises another question. Should we be doing this kind of check at all, and what really is the policy. Is the end time allowed to be in the future? I Noticed e.g. that add doesn't seem to be doing of these sanity checks. Should it?