### PR TITLE
Add day and week editing options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ site/
 .vagrant/
 .venv/
 .pytest_cache/
+data/
 
 # files
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -195,8 +195,8 @@ Flag | Help
 `-d, --day` | Edit all frames for today.
 `-w, --week` | Edit all frames for the past week.
 `-m, --month` | Edit all frames for the past month.
-`-f, --from` | The date from when the log should start.
-`-t, --to` | The date at which the log should stop (inclusive).
+`-f, --from` | The date from when the log should start. Defaults to seven days ago.
+`-t, --to` | The date at which the log should stop (inclusive). Defaults to tomorrow.
 `--help` | Show this message and exit.
 
 ## `frames`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -175,8 +175,9 @@ index. You can get the id of a frame with the `watson log` command.
 If no id or index is given, the frame defaults to the current frame (or the
 last recorded frame, if no project is currently running).
 
-If day or week is flagged, all the frames for that day or week will be 
-available for editing. If an id is also passed it will be ignored.
+If day, week or month is flagged, all the frames for that day, week or
+month will be available for editing. If an id is also passed it
+will be ignored.
 
 The editor used is determined by the `VISUAL` or `EDITOR` environment
 variables (in that order) and defaults to `notepad` on Windows systems and
@@ -190,6 +191,7 @@ Flag | Help
 `-b, --confirm-new-tag` | Confirm creation of new tag.
 `-d, --day` | Edit all frames for today.
 `-w, --week` | Edit all frames for the past week.
+ `-m, --month` | Edit all frames for the past month.
 `--help` | Show this message and exit.
 
 ## `frames`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -179,6 +179,9 @@ If day, week or month is flagged, all the frames for that day, week or
 month will be available for editing. If an id is also passed it
 will be ignored.
 
+If from and/or to are specified the frames within this range will be
+available for editing.
+
 The editor used is determined by the `VISUAL` or `EDITOR` environment
 variables (in that order) and defaults to `notepad` on Windows systems and
 to `vim`, `nano`, or `vi` (first one found) on all other systems.
@@ -192,6 +195,8 @@ Flag | Help
 `-d, --day` | Edit all frames for today.
 `-w, --week` | Edit all frames for the past week.
 `-m, --month` | Edit all frames for the past month.
+`-f, --from` | The date from when the log should start.
+`-t, --to` | The date at which the log should stop (inclusive).
 `--help` | Show this message and exit.
 
 ## `frames`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -166,18 +166,21 @@ Flag | Help
 Usage:  watson edit [OPTIONS] [ID]
 ```
 
-Edit a frame.
+Edit one or more frames.
 
 You can specify the frame to edit by its position or by its frame id.
 For example, to edit the second-to-last frame, pass `-2` as the frame
 index. You can get the id of a frame with the `watson log` command.
 
-If no id or index is given, the frame defaults to the current frame or the
-last recorded frame, if no project is currently running.
+If no id or index is given, the frame defaults to the current frame (or the
+last recorded frame, if no project is currently running).
+
+If day or week is flagged, all the frames for that day or week will be 
+available for editing. If an id is also passed it will be ignored.
 
 The editor used is determined by the `VISUAL` or `EDITOR` environment
 variables (in that order) and defaults to `notepad` on Windows systems and
-to `vim`, `nano` or `vi` (first one found) on all other systems.
+to `vim`, `nano`, or `vi` (first one found) on all other systems.
 
 ### Options
 
@@ -185,6 +188,8 @@ Flag | Help
 -----|-----
 `-c, --confirm-new-project` | Confirm addition of new project.
 `-b, --confirm-new-tag` | Confirm creation of new tag.
+`-d, --day` | Edit all frames for today.
+`-w, --week` | Edit all frames for the past week.
 `--help` | Show this message and exit.
 
 ## `frames`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -195,8 +195,8 @@ Flag | Help
 `-d, --day` | Edit all frames for today.
 `-w, --week` | Edit all frames for the past week.
 `-m, --month` | Edit all frames for the past month.
-`-f, --from` | The date from when the log should start. Defaults to seven days ago.
-`-t, --to` | The date at which the log should stop (inclusive). Defaults to tomorrow.
+`-f, --from` | The date from when the frames to edit should start. Defaults to seven days ago.
+`-t, --to` | The date at which the frames to edit should stop (inclusive). Defaults to tomorrow.
 `--help` | Show this message and exit.
 
 ## `frames`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -191,7 +191,7 @@ Flag | Help
 `-b, --confirm-new-tag` | Confirm creation of new tag.
 `-d, --day` | Edit all frames for today.
 `-w, --week` | Edit all frames for the past week.
- `-m, --month` | Edit all frames for the past month.
+`-m, --month` | Edit all frames for the past month.
 `--help` | Show this message and exit.
 
 ## `frames`

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,7 @@ except ImportError:
 try:
     from unittest.mock import patch, Mock
 except ImportError:
-    from mock import patch
+    from mock import patch, Mock
 import pytest
 from click.exceptions import Abort
 from dateutil.tz import tzutc

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -390,14 +390,14 @@ def test_json_arrow_encoder():
 
 # get_frames_for_today
 
-# @patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00')))
 def test_get_frames_for_today(watson):
     """
     This test will take the current time and create entries with
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+    mock_date = arrow.get('2020-07-29T23:00:00+00:00')
+    with patch('arrow.now', Mock(return_value=mock_date)):
         now = arrow.now()
         watson.add('foo', now.shift(hours=-1), now, ['1A'])
         watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
@@ -434,7 +434,8 @@ def test_get_frames_for_week(watson):
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+    mock_date = arrow.get('2020-07-29T23:00:00+00:00')
+    with patch('arrow.now', Mock(return_value=mock_date)):
         now = arrow.now()
         watson.add('foo', now.shift(hours=-1), now, ['1A'])
         watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
@@ -480,7 +481,8 @@ def test_get_frames_for_month(watson):
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+    mock_date = arrow.get('2020-07-29T23:00:00+00:00')
+    with patch('arrow.now', Mock(return_value=mock_date)):
         now = arrow.now()
         watson.add('foo', now.shift(hours=-1), now, ['1A'])
         watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
@@ -538,7 +540,8 @@ def test_get_frames_between(watson):
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+    mock_date = arrow.get('2020-07-29T23:00:00+00:00')
+    with patch('arrow.now', Mock(return_value=mock_date)):
         from_ = arrow.now().shift(days=-6)
         to = arrow.now().shift(days=-2)
         now = arrow.now()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -395,10 +395,6 @@ def test_get_frames_for_today(watson):
     This test will take the current time and create entries with
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
-
-    This test hardcodes the value of now (which should be dependent on the
-    user and the machine's current time) to avoid tests failing around 
-    midnight
     """
     now = arrow.now()
     watson.add('foo', now.shift(hours=-1), now, ['1A'])
@@ -534,6 +530,9 @@ def test_get_frames_for_month(watson):
 
 def test_get_frames_between(watson):
     """
+    This test will take the current time and create entries with
+    a starting point shifted by a designated number of hours. The test passes
+    if all the frames belonging to the specifid time frame are returned.
     """
     from_ = arrow.now().shift(days=-6)
     to = arrow.now().shift(days=-2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     from io import StringIO
 try:
-    from unittest.mock import patch
+    from unittest.mock import patch, Mock
 except ImportError:
     from mock import patch
 import pytest
@@ -390,38 +390,40 @@ def test_json_arrow_encoder():
 
 # get_frames_for_today
 
+# @patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00')))
 def test_get_frames_for_today(watson):
     """
     This test will take the current time and create entries with
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    now = arrow.now()
-    watson.add('foo', now.shift(hours=-1), now, ['1A'])
-    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
-    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
-    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
-    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
-    watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
+    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+        now = arrow.now()
+        watson.add('foo', now.shift(hours=-1), now, ['1A'])
+        watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
+        watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
+        watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
+        watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
+        watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
 
-    result = get_frames_for_today(watson)
+        result = get_frames_for_today(watson)
 
-    assert len(result) == 3
+        assert len(result) == 3
 
-    assert result[0].start == now.shift(hours=-1)
-    assert result[0].stop == now
-    assert result[0].project == 'foo'
-    assert result[0].tags == ['1A']
+        assert result[0].start == now.shift(hours=-1)
+        assert result[0].stop == now
+        assert result[0].project == 'foo'
+        assert result[0].tags == ['1A']
 
-    assert result[1].start == now.shift(hours=-5)
-    assert result[1].stop == now.shift(hours=-3)
-    assert result[1].project == 'foo'
-    assert result[1].tags == ['5A']
+        assert result[1].start == now.shift(hours=-5)
+        assert result[1].stop == now.shift(hours=-3)
+        assert result[1].project == 'foo'
+        assert result[1].tags == ['5A']
 
-    assert result[2].start == now.shift(hours=-8)
-    assert result[2].stop == now.shift(hours=-5)
-    assert result[2].project == 'foo'
-    assert result[2].tags == ['8A']
+        assert result[2].start == now.shift(hours=-8)
+        assert result[2].stop == now.shift(hours=-5)
+        assert result[2].project == 'foo'
+        assert result[2].tags == ['8A']
 
 
 # get_frames_for_week
@@ -432,41 +434,42 @@ def test_get_frames_for_week(watson):
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    now = arrow.now()
-    watson.add('foo', now.shift(hours=-1), now, ['1A'])
-    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
-    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
-    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
-    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
-    watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
-    watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
-    watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
-    watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
-    watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
+    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+        now = arrow.now()
+        watson.add('foo', now.shift(hours=-1), now, ['1A'])
+        watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
+        watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
+        watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
+        watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
+        watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
+        watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
+        watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
+        watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
+        watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
 
-    result = get_frames_for_week(watson)
+        result = get_frames_for_week(watson)
 
-    assert len(result) == 8
+        assert len(result) == 8
 
-    assert result[0].start == now.shift(hours=-1)
-    assert result[0].stop == now
-    assert result[0].project == 'foo'
-    assert result[0].tags == ['1A']
+        assert result[0].start == now.shift(hours=-1)
+        assert result[0].stop == now
+        assert result[0].project == 'foo'
+        assert result[0].tags == ['1A']
 
-    assert result[1].start == now.shift(hours=-5)
-    assert result[1].stop == now.shift(hours=-3)
-    assert result[1].project == 'foo'
-    assert result[1].tags == ['5A']
+        assert result[1].start == now.shift(hours=-5)
+        assert result[1].stop == now.shift(hours=-3)
+        assert result[1].project == 'foo'
+        assert result[1].tags == ['5A']
 
-    assert result[2].start == now.shift(hours=-8)
-    assert result[2].stop == now.shift(hours=-5)
-    assert result[2].project == 'foo'
-    assert result[2].tags == ['8A']
+        assert result[2].start == now.shift(hours=-8)
+        assert result[2].stop == now.shift(hours=-5)
+        assert result[2].project == 'foo'
+        assert result[2].tags == ['8A']
 
-    assert result[7].start == now.shift(days=-7)
-    assert result[7].stop == now.shift(hours=-150)
-    assert result[7].project == 'foo'
-    assert result[7].tags == ['168L']
+        assert result[7].start == now.shift(days=-7)
+        assert result[7].stop == now.shift(hours=-150)
+        assert result[7].project == 'foo'
+        assert result[7].tags == ['168L']
 
 
 # get_frames_for_month
@@ -477,53 +480,54 @@ def test_get_frames_for_month(watson):
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    now = arrow.now()
-    watson.add('foo', now.shift(hours=-1), now, ['1A'])
-    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
-    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
-    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
-    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
-    watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
-    watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
-    watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
-    watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
-    watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
-    watson.add('foo', now.shift(days=-30), now.shift(hours=-718), ['720L'])
-    watson.add('foo', now.shift(days=-35), now.shift(hours=-835), ['840L'])
+    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+        now = arrow.now()
+        watson.add('foo', now.shift(hours=-1), now, ['1A'])
+        watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
+        watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
+        watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
+        watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
+        watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
+        watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
+        watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
+        watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
+        watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
+        watson.add('foo', now.shift(days=-30), now.shift(hours=-718), ['720L'])
+        watson.add('foo', now.shift(days=-35), now.shift(hours=-835), ['840L'])
 
-    result = get_frames_for_month(watson)
+        result = get_frames_for_month(watson)
 
-    assert len(result) == 11
+        assert len(result) == 11
 
-    assert result[0].start == now.shift(hours=-1)
-    assert result[0].stop == now
-    assert result[0].project == 'foo'
-    assert result[0].tags == ['1A']
+        assert result[0].start == now.shift(hours=-1)
+        assert result[0].stop == now
+        assert result[0].project == 'foo'
+        assert result[0].tags == ['1A']
 
-    assert result[1].start == now.shift(hours=-5)
-    assert result[1].stop == now.shift(hours=-3)
-    assert result[1].project == 'foo'
-    assert result[1].tags == ['5A']
+        assert result[1].start == now.shift(hours=-5)
+        assert result[1].stop == now.shift(hours=-3)
+        assert result[1].project == 'foo'
+        assert result[1].tags == ['5A']
 
-    assert result[2].start == now.shift(hours=-8)
-    assert result[2].stop == now.shift(hours=-5)
-    assert result[2].project == 'foo'
-    assert result[2].tags == ['8A']
+        assert result[2].start == now.shift(hours=-8)
+        assert result[2].stop == now.shift(hours=-5)
+        assert result[2].project == 'foo'
+        assert result[2].tags == ['8A']
 
-    assert result[7].start == now.shift(days=-7)
-    assert result[7].stop == now.shift(hours=-150)
-    assert result[7].project == 'foo'
-    assert result[7].tags == ['168L']
+        assert result[7].start == now.shift(days=-7)
+        assert result[7].stop == now.shift(hours=-150)
+        assert result[7].project == 'foo'
+        assert result[7].tags == ['168L']
 
-    assert result[9].start == now.shift(days=-13)
-    assert result[9].stop == now.shift(hours=-300)
-    assert result[9].project == 'foo'
-    assert result[9].tags == ['312L']
+        assert result[9].start == now.shift(days=-13)
+        assert result[9].stop == now.shift(hours=-300)
+        assert result[9].project == 'foo'
+        assert result[9].tags == ['312L']
 
-    assert result[10].start == now.shift(days=-30)
-    assert result[10].stop == now.shift(hours=-718)
-    assert result[10].project == 'foo'
-    assert result[10].tags == ['720L']
+        assert result[10].start == now.shift(days=-30)
+        assert result[10].stop == now.shift(hours=-718)
+        assert result[10].project == 'foo'
+        assert result[10].tags == ['720L']
 
 
 # get_frames_between
@@ -534,32 +538,33 @@ def test_get_frames_between(watson):
     a starting point shifted by a designated number of hours. The test passes
     if all the frames belonging to the specifid time frame are returned.
     """
-    from_ = arrow.now().shift(days=-6)
-    to = arrow.now().shift(days=-2)
-    now = arrow.now()
-    watson.add('foo', now.shift(hours=-1), now, ['1A'])
-    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
-    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
-    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
-    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
-    watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
-    watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
-    watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
-    watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
-    watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
-    watson.add('foo', now.shift(days=-30), now.shift(hours=-718), ['720L'])
-    watson.add('foo', now.shift(days=-35), now.shift(hours=-835), ['840L'])
+    with patch('arrow.now', Mock(return_value=arrow.get('2020-07-29T23:00:00+00:00'))):
+        from_ = arrow.now().shift(days=-6)
+        to = arrow.now().shift(days=-2)
+        now = arrow.now()
+        watson.add('foo', now.shift(hours=-1), now, ['1A'])
+        watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
+        watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
+        watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
+        watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
+        watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
+        watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
+        watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
+        watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
+        watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
+        watson.add('foo', now.shift(days=-30), now.shift(hours=-718), ['720L'])
+        watson.add('foo', now.shift(days=-35), now.shift(hours=-835), ['840L'])
 
-    result = get_frames_between(watson, from_, to)
+        result = get_frames_between(watson, from_, to)
 
-    assert len(result) == 2
+        assert len(result) == 2
 
-    assert result[0].start == now.shift(days=-3)
-    assert result[0].stop == now.shift(hours=-70)
-    assert result[0].project == 'foo'
-    assert result[0].tags == ['72L']
+        assert result[0].start == now.shift(days=-3)
+        assert result[0].stop == now.shift(hours=-70)
+        assert result[0].project == 'foo'
+        assert result[0].tags == ['72L']
 
-    assert result[1].start == now.shift(days=-5)
-    assert result[1].stop == now.shift(hours=-110)
-    assert result[1].project == 'foo'
-    assert result[1].tags == ['120L']
+        assert result[1].start == now.shift(days=-5)
+        assert result[1].stop == now.shift(hours=-110)
+        assert result[1].project == 'foo'
+        assert result[1].tags == ['120L']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -390,15 +390,13 @@ def test_json_arrow_encoder():
 
 def test_get_frames_for_today(watson):
     now = arrow.now()
-    watson.add('foo', now.shift(hours=-1), now, ['1A', '1B', '1C'])
-    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A', '5B', '5C'])
-    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A', '8B', '8C'])
-    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F', '24G', '24H'])
-    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I', '48J', '48K'])
+    watson.add('foo', now.shift(hours=-1), now, ['1A'])
+    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
+    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
+    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
+    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
     watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
 
-    start = now.shift(hours=-now.hour)
-    stop = now
     result = get_frames_for_today(watson)
 
     assert len(result) == 3
@@ -406,36 +404,34 @@ def test_get_frames_for_today(watson):
     assert result[0].start == now.shift(hours=-1)
     assert result[0].stop == now
     assert result[0].project == 'foo'
-    assert result[0].tags == ['1A', '1B', '1C']
+    assert result[0].tags == ['1A']
 
     assert result[1].start == now.shift(hours=-5)
     assert result[1].stop == now.shift(hours=-3)
     assert result[1].project == 'foo'
-    assert result[1].tags == ['5A', '5B', '5C']
+    assert result[1].tags == ['5A']
 
     assert result[2].start == now.shift(hours=-8)
     assert result[2].stop == now.shift(hours=-5)
     assert result[2].project == 'foo'
-    assert result[2].tags == ['8A', '8B', '8C']
+    assert result[2].tags == ['8A']
 
 
 # get_frames_for_week
 
 def test_get_frames_for_week(watson):
     now = arrow.now()
-    watson.add('foo', now.shift(hours=-1), now, ['1A', '1B', '1C'])
-    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A', '5B', '5C'])
-    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A', '8B', '8C'])
-    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F', '24G', '24H'])
-    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I', '48J', '48K'])
+    watson.add('foo', now.shift(hours=-1), now, ['1A'])
+    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
+    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
+    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
+    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
     watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
     watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
     watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
     watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
     watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
 
-    start = now.shift(weeks=-1)
-    stop = now
     result = get_frames_for_week(watson)
 
     assert len(result) == 8
@@ -443,17 +439,17 @@ def test_get_frames_for_week(watson):
     assert result[0].start == now.shift(hours=-1)
     assert result[0].stop == now
     assert result[0].project == 'foo'
-    assert result[0].tags == ['1A', '1B', '1C']
+    assert result[0].tags == ['1A']
 
     assert result[1].start == now.shift(hours=-5)
     assert result[1].stop == now.shift(hours=-3)
     assert result[1].project == 'foo'
-    assert result[1].tags == ['5A', '5B', '5C']
+    assert result[1].tags == ['5A']
 
     assert result[2].start == now.shift(hours=-8)
     assert result[2].stop == now.shift(hours=-5)
     assert result[2].project == 'foo'
-    assert result[2].tags == ['8A', '8B', '8C']
+    assert result[2].tags == ['8A']
 
     assert result[7].start == now.shift(days=-7)
     assert result[7].stop == now.shift(hours=-150)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,7 @@ from watson.utils import (
     get_start_time_for_period,
     get_frames_for_today,
     get_frames_for_week,
+    get_frames_for_month,
     make_json_writer,
     safe_save,
     sorted_groupby,
@@ -389,7 +390,12 @@ def test_json_arrow_encoder():
 # get_frames_for_today
 
 def test_get_frames_for_today(watson):
-    now = arrow.now()
+    """
+    This test will take the current time and create entries with
+    a starting point shifted by a designated number of hours. The test passes
+    if all the frames belonging to the specifid time frame are returned.
+    """
+    now = arrow.utcnow()
     watson.add('foo', now.shift(hours=-1), now, ['1A'])
     watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
     watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
@@ -420,7 +426,12 @@ def test_get_frames_for_today(watson):
 # get_frames_for_week
 
 def test_get_frames_for_week(watson):
-    now = arrow.now()
+    """
+    This test will take the current time and create entries with
+    a starting point shifted by a designated number of hours. The test passes
+    if all the frames belonging to the specifid time frame are returned.
+    """
+    now = arrow.utcnow()
     watson.add('foo', now.shift(hours=-1), now, ['1A'])
     watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
     watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
@@ -455,3 +466,60 @@ def test_get_frames_for_week(watson):
     assert result[7].stop == now.shift(hours=-150)
     assert result[7].project == 'foo'
     assert result[7].tags == ['168L']
+
+
+# get_frames_for_month
+
+def test_get_frames_for_month(watson):
+    """
+    This test will take the current time and create entries with
+    a starting point shifted by a designated number of hours. The test passes
+    if all the frames belonging to the specifid time frame are returned.
+    """
+    now = arrow.utcnow()
+    watson.add('foo', now.shift(hours=-1), now, ['1A'])
+    watson.add('foo', now.shift(hours=-5), now.shift(hours=-3), ['5A'])
+    watson.add('foo', now.shift(hours=-8), now.shift(hours=-5), ['8A'])
+    watson.add('foo', now.shift(days=-1), now.shift(hours=-20), ['24F'])
+    watson.add('foo', now.shift(days=-2), now.shift(hours=-42), ['48I'])
+    watson.add('foo', now.shift(days=-3), now.shift(hours=-70), ['72L'])
+    watson.add('foo', now.shift(days=-5), now.shift(hours=-110), ['120L'])
+    watson.add('foo', now.shift(days=-7), now.shift(hours=-150), ['168L'])
+    watson.add('foo', now.shift(days=-10), now.shift(hours=-210), ['240L'])
+    watson.add('foo', now.shift(days=-13), now.shift(hours=-300), ['312L'])
+    watson.add('foo', now.shift(days=-30), now.shift(hours=-718), ['720L'])
+    watson.add('foo', now.shift(days=-35), now.shift(hours=-835), ['840L'])
+
+    result = get_frames_for_month(watson)
+
+    assert len(result) == 11
+
+    assert result[0].start == now.shift(hours=-1)
+    assert result[0].stop == now
+    assert result[0].project == 'foo'
+    assert result[0].tags == ['1A']
+
+    assert result[1].start == now.shift(hours=-5)
+    assert result[1].stop == now.shift(hours=-3)
+    assert result[1].project == 'foo'
+    assert result[1].tags == ['5A']
+
+    assert result[2].start == now.shift(hours=-8)
+    assert result[2].stop == now.shift(hours=-5)
+    assert result[2].project == 'foo'
+    assert result[2].tags == ['8A']
+
+    assert result[7].start == now.shift(days=-7)
+    assert result[7].stop == now.shift(hours=-150)
+    assert result[7].project == 'foo'
+    assert result[7].tags == ['168L']
+
+    assert result[9].start == now.shift(days=-13)
+    assert result[9].stop == now.shift(hours=-300)
+    assert result[9].project == 'foo'
+    assert result[9].tags == ['312L']
+
+    assert result[10].start == now.shift(days=-30)
+    assert result[10].stop == now.shift(hours=-718)
+    assert result[10].project == 'foo'
+    assert result[10].tags == ['720L']

--- a/watson.fish
+++ b/watson.fish
@@ -115,6 +115,11 @@ complete -f -c watson -n '__fish_watson_using_command config' -s e -l edit -d "E
 # edit
 complete -f -c watson -n '__fish_watson_needs_sub' -a edit -d "Edit a frame"
 complete -f -c watson -n '__fish_watson_using_command edit' -a "(__fish_watson_get_frames)"
+complete -f -c watson -n '__fish_watson_using_command edit' -s d -l day -d "all frames for today"
+complete -f -c watson -n '__fish_watson_using_command edit' -s w -l week -d "all frames for the past week"
+complete -f -c watson -n '__fish_watson_using_command edit' -s m -l month -d "all frames for the past month"
+complete -f -c watson -n '__fish_watson_using_command edit' -s f -l from -d "start date of the frames"
+complete -f -c watson -n '__fish_watson_using_command edit' -s t -l to -d "end date of the frames (inclusive)"
 
 # log
 complete -f -c watson -n '__fish_watson_needs_sub' -a log -d "Display sessions during the given timespan"

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1232,11 +1232,11 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
 @click.option('-f', '--from', 'from_', type=DateTime,
               help="The date from when the log should start.")
 @click.option('-t', '--to', type=DateTime, default=arrow.now(),
-              help="The date at which the log should stop (inclusive). ")
+              help="The date at which the log should stop (inclusive).")
 @click.argument('id', required=False, autocompletion=get_frames)
 @click.pass_obj
 @catch_watson_error
-def edit(watson, confirm_new_project, confirm_new_tag, day, week, 
+def edit(watson, confirm_new_project, confirm_new_tag, day, week,
          month, from_, to, id):
     """
     Edit one or more frames.
@@ -1364,7 +1364,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week,
                 # Add frame to the list of edited frames only if it's been
                 #  edited
                 if frame != data[index]:
-                    edited_frames.append((frame_id, project, start, stop, tags))
+                    edited_frames.append((frame_id, project, start,
+                                          stop, tags))
             # break out of while loop and continue execution of
             #  the edit function normally
             break

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1231,11 +1231,11 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
               help="Edit all frames for the past month.")
 @click.option('-f', '--from', 'from_', type=DateTime,
               default=arrow.now().shift(days=-7),
-              help="The date from when the log should start. Defaults "
-              "to seven days ago.")
+              help="The date from when the frames to edit should start. "
+              "Defaults to seven days ago.")
 @click.option('-t', '--to', type=DateTime, default=arrow.now(),
-              help="The date at which the log should stop (inclusive). "
-              "Defaults to tomorrow.")
+              help="The date at which the frames to edit should stop "
+              "(inclusive). Defaults to tomorrow.")
 @click.argument('id', required=False, autocompletion=get_frames)
 @click.pass_obj
 @catch_watson_error

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1347,8 +1347,10 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week, month, id):
                                         ensure_ascii=False)
                     raise ValueError("You cannot rearrange the order of the \
                                       frames or modify their ids.")
-                # Add frame to the list of edited frames
-                edited_frames.append((frame_id, project, start, stop, tags))
+                # Add frame to the list of edited frames only if it's been
+                #  edited
+                if frame != data[index]:
+                    edited_frames.append((frame_id, project, start, stop, tags))
             # break out of while loop and continue execution of
             #  the edit function normally
             break

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1230,9 +1230,12 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
 @click.option('-m', '--month', is_flag=True, default=False,
               help="Edit all frames for the past month.")
 @click.option('-f', '--from', 'from_', type=DateTime,
-              help="The date from when the log should start.")
+              default=arrow.now().shift(days=-7),
+              help="The date from when the log should start. Defaults "
+              "to seven days ago.")
 @click.option('-t', '--to', type=DateTime, default=arrow.now(),
-              help="The date at which the log should stop (inclusive).")
+              help="The date at which the log should stop (inclusive). "
+              "Defaults to tomorrow.")
 @click.argument('id', required=False, autocompletion=get_frames)
 @click.pass_obj
 @catch_watson_error

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1239,7 +1239,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week, id):
     If no id or index is given, the frame defaults to the current frame (or the
     last recorded frame, if no project is currently running).
 
-    If day or week is flagged, all the frames for that day or week will be 
+    If day or week is flagged, all the frames for that day or week will be
     available for editing. If an id is also passed it will be ignored.
 
     The editor used is determined by the `VISUAL` or `EDITOR` environment
@@ -1263,8 +1263,9 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week, id):
         id = frames[0].id
     elif watson.is_started:
         # Frame is started and doesn't have a stop time yet
-        frames = [Frame(watson.current['start'], None, watson.current['project'],
-                      None, watson.current['tags'])]
+        frames = [Frame(watson.current['start'], None,
+                        watson.current['project'], None,
+                        watson.current['tags'])]
     elif watson.frames:
         # Id is not provided, edit the latest frame
         frames = [watson.frames[-1]]
@@ -1277,7 +1278,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week, id):
         {
             'id': frame.id,
             'start': frame.start.format(datetime_format),
-            'stop': frame.stop.format(datetime_format) if frame.stop or id else None,
+            'stop': frame.stop.format(datetime_format)
+            if frame.stop or id else None,
             'project': frame.project,
             'tags': frame.tags,
         }
@@ -1306,8 +1308,8 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week, id):
                 project = frame['project']
                 frame_id = frame['id']
                 # Confirm creation of new project if that option is set
-                if (watson.config.getboolean('options', 'confirm_new_project') or
-                        confirm_new_project):
+                if (watson.config.getboolean('options', 'confirm_new_project')
+                        or confirm_new_project):
                     confirm_project(project, watson.projects)
                 tags = frame['tags']
                 # Confirm creation of new tag(s) if that option is set
@@ -1332,8 +1334,10 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week, id):
                 if frame['id'] != data[index]['id']:
                     # Reset the id to the original value
                     edited_data[index]['id'] = data[index]['id']
-                    output = json.dumps(edited_data, indent=4, sort_keys=True, ensure_ascii=False)
-                    raise ValueError("You cannot rearrange the order of the frames or modify their ids.")
+                    output = json.dumps(edited_data, indent=4, sort_keys=True,
+                                        ensure_ascii=False)
+                    raise ValueError("You cannot rearrange the order of the \
+                                      frames or modify their ids.")
                 # Add frame to the list of edited frames
                 edited_frames.append((frame_id, project, start, stop, tags))
             # break out of while loop and continue execution of
@@ -1366,7 +1370,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, day, week, id):
     for frame in edited_frames:
         (id, project, start, stop, tags) = frame
         click.echo(
-            u"Edited frame for project {project}{tags}, from {start} to {stop} "
+            u"Edited frame for project {project}{tags}, from {start} to {stop}"
             u"({delta})".format(
                 delta=format_timedelta(stop - start) if stop else '-',
                 project=style('project', project),

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -211,6 +211,25 @@ def get_frames_for_month(watson):
     return entries
 
 
+def get_frames_between(watson, from_, to):
+    """
+    Get frames between range.
+    """
+    # from_ = arrow.get(from_)
+    # to = arrow.get(to)
+    # entries = [
+    #     frame
+    #     for frame in watson.frames
+    #     if frame.start >= from_ and frame.stop <= to
+    # ]
+    span = watson.frames.span(from_, to)
+    entries = [
+        frame
+        for frame in watson.frames.filter(span=span)
+    ]
+    return entries
+
+
 def get_start_time_for_period(period):
     # Using now() from datetime instead of arrow for mocking compatibility.
     now = arrow.Arrow.fromdatetime(datetime.datetime.now())

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -215,13 +215,6 @@ def get_frames_between(watson, from_, to):
     """
     Get frames between range.
     """
-    # from_ = arrow.get(from_)
-    # to = arrow.get(to)
-    # entries = [
-    #     frame
-    #     for frame in watson.frames
-    #     if frame.start >= from_ and frame.stop <= to
-    # ]
     span = watson.frames.span(from_, to)
     entries = [
         frame

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -176,11 +176,11 @@ def get_frames_for_today(watson):
     """
     Get frames for today.
     """
-    today = arrow.now().format('YYYY-MM-DD')
+    today = arrow.now()
+    span = watson.frames.span(today, today)
     entries = [
         frame
-        for frame in watson.frames
-        if frame.start.format('YYYY-MM-DD') == today
+        for frame in watson.frames.filter(span=span)
     ]
     return entries
 
@@ -189,11 +189,11 @@ def get_frames_for_week(watson):
     """
     Get frames for current week.
     """
-    week_ago = arrow.now().shift(weeks=-1).format('YYYY-MM-DD')
+    week_ago = arrow.now().shift(weeks=-1)
+    span = watson.frames.span(week_ago, arrow.now())
     entries = [
         frame
-        for frame in watson.frames
-        if frame.start.format('YYYY-MM-DD') >= week_ago
+        for frame in watson.frames.filter(span=span)
     ]
     return entries
 
@@ -202,11 +202,11 @@ def get_frames_for_month(watson):
     """
     Get frames for current month.
     """
-    month_ago = arrow.now().shift(months=-1).format('YYYY-MM-DD')
+    month_ago = arrow.now().shift(months=-1)
+    span = watson.frames.span(month_ago, arrow.now())
     entries = [
         frame
-        for frame in watson.frames
-        if frame.start.format('YYYY-MM-DD') >= month_ago
+        for frame in watson.frames.filter(span=span)
     ]
     return entries
 

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -176,36 +176,39 @@ def get_frames_for_today(watson):
     """
     Get frames for today.
     """
-    try:
-        today = arrow.now().format('YYYY-MM-DD')
-        entries = [
-            frame
-            for frame in watson.frames
-            if frame.start.format('YYYY-MM-DD') == today
-        ]
-        return entries
-    except KeyError:
-        raise click.ClickException(u"{}.".format(
-            style('error', u"No frame found with id"))
-        )
+    today = arrow.now().format('YYYY-MM-DD')
+    entries = [
+        frame
+        for frame in watson.frames
+        if frame.start.format('YYYY-MM-DD') == today
+    ]
+    return entries
 
 
 def get_frames_for_week(watson):
     """
     Get frames for current week.
     """
-    try:
-        week_ago = arrow.now().shift(weeks=-1).format('YYYY-MM-DD')
-        entries = [
-            frame
-            for frame in watson.frames
-            if frame.start.format('YYYY-MM-DD') >= week_ago
-        ]
-        return entries
-    except KeyError:
-        raise click.ClickException(u"{}.".format(
-            style('error', u"No frame found with id"))
-        )
+    week_ago = arrow.now().shift(weeks=-1).format('YYYY-MM-DD')
+    entries = [
+        frame
+        for frame in watson.frames
+        if frame.start.format('YYYY-MM-DD') >= week_ago
+    ]
+    return entries
+
+
+def get_frames_for_month(watson):
+    """
+    Get frames for current month.
+    """
+    month_ago = arrow.now().shift(months=-1).format('YYYY-MM-DD')
+    entries = [
+        frame
+        for frame in watson.frames
+        if frame.start.format('YYYY-MM-DD') >= month_ago
+    ]
+    return entries
 
 
 def get_start_time_for_period(period):

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -172,6 +172,42 @@ def get_frame_from_argument(watson, arg):
         )
 
 
+def get_frames_for_today(watson):
+    """
+    Get frames for today.
+    """
+    try:
+        today = arrow.now().format('YYYY-MM-DD')
+        entries = [
+            frame
+            for frame in watson.frames
+            if frame.start.format('YYYY-MM-DD') == today
+        ]
+        return entries
+    except KeyError:
+        raise click.ClickException(u"{}.".format(
+            style('error', u"No frame found with id"))
+        )
+
+
+def get_frames_for_week(watson):
+    """
+    Get frames for current week.
+    """
+    try:
+        week_ago = arrow.now().shift(weeks=-1).format('YYYY-MM-DD')
+        entries = [
+            frame
+            for frame in watson.frames
+            if frame.start.format('YYYY-MM-DD') >= week_ago
+        ]
+        return entries
+    except KeyError:
+        raise click.ClickException(u"{}.".format(
+            style('error', u"No frame found with id"))
+        )
+
+
 def get_start_time_for_period(period):
     # Using now() from datetime instead of arrow for mocking compatibility.
     now = arrow.Arrow.fromdatetime(datetime.datetime.now())


### PR DESCRIPTION
A useful feature for daily Watson users (like myself) is having the ability to edit all the entries of a given day or week (generally towards the end of the day | week). This PR provides 5 new optional flags to the `edit` command:

```
`-d, --day` | Edit all frames for today.
`-w, --week` | Edit all frames for the past week.
`-m, --month` | Edit all frames for the past month.
`-f, --from` | The date from when the log should start.
`-t, --to` | The date at which the log should stop (inclusive).
```

If day, week or month are passed, all the frames for that day, week or month will be available for editing. If an id is also passed it will be ignored.

If from and/or to are specified the frames within this range will be available for editing.

**Notes:**
- [x] Unit tests have been included for the newly added utility functions
- [x] Documentation has been updated to reflect the new flags
- [x] API was maintained and is consistent with what's released right now