### PR TITLE
docs: fix simple typo, succesful -> successful

### DIFF
--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1290,7 +1290,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
     start = None
     stop = None
 
-    # enter into while loop until succesful and validated
+    # enter into while loop until successful and validated
     #  edit has been performed
     while True:
         output = click.edit(text, extension='.json')


### PR DESCRIPTION
There is a small typo in watson/cli.py.

Should read `successful` rather than `succesful`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md