### PR TITLE
Add support for Python 3.8 and 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py37
+        - python: 3.8
+          os: linux
+          dist: xenial
+          env: TOXENV=py38
+        - python: 3.9
+          os: linux
+          dist: xenial
+          env: TOXENV=py39
 
 install:
   - pip install tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `log` command output can now be filtered to exclude projects and tags via `--ignore-project` and `--ignore-tag` (#395)
+- Python 3.8 support (#402)
+- Python 3.9 support (#402)
 
 ### Removed
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -8,7 +8,7 @@ Watson configuration and data are stored inside your user's application folder. 
 * **Windows**: `%appdata%\watson\config`, which usually expands to `C:\Users\<user>\AppData\Roaming\watson\config`
 * **Linux**: `~/.config/watson/config`
 
-The configuration file is a typical [python configuration (INI) file](https://docs.python.org/3.7/library/configparser.html#supported-ini-file-structure), that looks like:
+The configuration file is a typical [python configuration (INI) file](https://docs.python.org/3.9/library/configparser.html#supported-ini-file-structure), that looks like:
 
 ```ini
 [Simple Values]
@@ -55,7 +55,7 @@ empty string value here =
         # Did I mention we can indent comments, too?
 ```
 
-_This example configuration file has been taken from the [official python documentation](https://docs.python.org/3.7/library/configparser.html#supported-ini-file-structure)._
+_This example configuration file has been taken from the [official python documentation](https://docs.python.org/3.9/library/configparser.html#supported-ini-file-structure)._
 
 
 ## Editing

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Office/Business",
         "Topic :: Utilities",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py35,py36,py37
+envlist = flake8,py35,py36,py37,py38,py39
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Both versions now used when testing the code. This might prevent
regressions with regard to these versions.