### PR TITLE
Issue #407: Migrate to arrow 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=flake8
-        - python: 3.5
-          os: linux
-          dist: trusty
-          env: TOXENV=py35
         - python: 3.6
           os: linux
           dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python 3.8 support (#402)
 - Python 3.9 support (#402)
 
+### Changed
+
+- Upgrade to major arrow release 1.0.0 (#407)
+
 ### Removed
 
 - Python 2.7 support (#305).
+- Python 3.5 support (#407).
 
 ## [1.10.0] - 2020-07-03
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow>=0.15.6
+arrow==1.0.0
 click>=7.0
 click-didyoumean
 colorama; sys_platform == "win32"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow==1.0.0
+arrow>=1.0.0
 click>=7.0
 click-didyoumean
 colorama; sys_platform == "win32"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     license='MIT',
     long_description=readme,
     install_requires=parse_requirements('requirements.txt'),
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     tests_require=parse_requirements('requirements-dev.txt'),
     entry_points={
         'console_scripts': [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,14 +172,14 @@ def test_report_invalid_date(runner, watson, test_dt):
 
 @pytest.mark.parametrize('at_dt', VALID_TIMES_DATA)
 def test_stop_valid_time(runner, watson, mocker, at_dt):
-    mocker.patch('arrow.arrow.datetime', wraps=datetime)
+    mocker.patch('arrow.arrow.dt_datetime', wraps=datetime)
     start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=tzlocal())
-    arrow.arrow.datetime.now.return_value = start_dt
+    arrow.arrow.dt_datetime.now.return_value = start_dt
     result = runner.invoke(cli.start, ['a-project'], obj=watson)
     assert result.exit_code == 0
     # Simulate one hour has elapsed, so that 'at_dt' is older than now()
     # but newer than the start date.
-    arrow.arrow.datetime.now.return_value = (start_dt + timedelta(hours=1))
+    arrow.arrow.dt_datetime.now.return_value = (start_dt + timedelta(hours=1))
     result = runner.invoke(cli.stop, ['--at', at_dt], obj=watson)
     assert result.exit_code == 0
 
@@ -189,8 +189,8 @@ def test_stop_valid_time(runner, watson, mocker, at_dt):
 @pytest.mark.parametrize('at_dt', VALID_TIMES_DATA)
 def test_start_valid_time(runner, watson, mocker, at_dt):
     # Simulate a start date so that 'at_dt' is older than now().
-    mocker.patch('arrow.arrow.datetime', wraps=datetime)
+    mocker.patch('arrow.arrow.dt_datetime', wraps=datetime)
     start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=tzlocal())
-    arrow.arrow.datetime.now.return_value = (start_dt + timedelta(hours=1))
+    arrow.arrow.dt_datetime.now.return_value = (start_dt + timedelta(hours=1))
     result = runner.invoke(cli.start, ['a-project', '--at', at_dt], obj=watson)
     assert result.exit_code == 0

--- a/tests/test_watson.py
+++ b/tests/test_watson.py
@@ -76,7 +76,7 @@ def test_current_with_empty_given_state(config_dir, mocker):
 
 def test_last_sync(mocker, watson):
     now = arrow.get(4123)
-    content = json.dumps(now.timestamp)
+    content = json.dumps(now.int_timestamp)
 
     mocker.patch('builtins.open', mocker.mock_open(read_data=content))
     assert watson.last_sync == now
@@ -482,7 +482,7 @@ def test_save_last_sync(mocker, watson, json_mock):
     watson.save()
 
     assert json_mock.call_count == 1
-    assert json_mock.call_args[0][0] == now.timestamp
+    assert json_mock.call_args[0][0] == now.int_timestamp
 
 
 def test_save_empty_last_sync(config_dir, mocker, json_mock):
@@ -682,14 +682,14 @@ def test_pull(mocker, watson):
 
     assert watson.frames[0].id == '1c006c6e6cc14c80ab22b51c857c0b06'
     assert watson.frames[0].project == 'foo'
-    assert watson.frames[0].start.timestamp == 4003
-    assert watson.frames[0].stop.timestamp == 4004
+    assert watson.frames[0].start.int_timestamp == 4003
+    assert watson.frames[0].stop.int_timestamp == 4004
     assert watson.frames[0].tags == ['A']
 
     assert watson.frames[1].id == 'c44aa8154d774a58bddd1afa95562141'
     assert watson.frames[1].project == 'bar'
-    assert watson.frames[1].start.timestamp == 4004
-    assert watson.frames[1].stop.timestamp == 4005
+    assert watson.frames[1].start.int_timestamp == 4004
+    assert watson.frames[1].stop.int_timestamp == 4005
     assert watson.frames[1].tags == []
 
 
@@ -888,18 +888,18 @@ def test_rename_project_with_time(watson):
 
     assert watson.frames[0].id == 'c76d1ad0282c429595cc566d7098c165'
     assert watson.frames[0].project == 'baz'
-    assert watson.frames[0].start.timestamp == 4001
-    assert watson.frames[0].stop.timestamp == 4002
+    assert watson.frames[0].start.int_timestamp == 4001
+    assert watson.frames[0].stop.int_timestamp == 4002
     assert watson.frames[0].tags == ['some_tag']
-    # assert watson.frames[0].updated_at.timestamp == 9000
-    assert watson.frames[0].updated_at.timestamp > 4005
+    # assert watson.frames[0].updated_at.int_timestamp == 9000
+    assert watson.frames[0].updated_at.int_timestamp > 4005
 
     assert watson.frames[1].id == 'eed598ff363d42658a095ae6c3ae1088'
     assert watson.frames[1].project == 'bar'
-    assert watson.frames[1].start.timestamp == 4010
-    assert watson.frames[1].stop.timestamp == 4015
+    assert watson.frames[1].start.int_timestamp == 4010
+    assert watson.frames[1].stop.int_timestamp == 4015
     assert watson.frames[1].tags == ['other_tag']
-    assert watson.frames[1].updated_at.timestamp == 4035
+    assert watson.frames[1].updated_at.int_timestamp == 4035
 
 
 def test_rename_tag_with_time(watson):
@@ -922,18 +922,18 @@ def test_rename_tag_with_time(watson):
 
     assert watson.frames[0].id == 'c76d1ad0282c429595cc566d7098c165'
     assert watson.frames[0].project == 'foo'
-    assert watson.frames[0].start.timestamp == 4001
-    assert watson.frames[0].stop.timestamp == 4002
+    assert watson.frames[0].start.int_timestamp == 4001
+    assert watson.frames[0].stop.int_timestamp == 4002
     assert watson.frames[0].tags == ['some_tag']
-    assert watson.frames[0].updated_at.timestamp == 4005
+    assert watson.frames[0].updated_at.int_timestamp == 4005
 
     assert watson.frames[1].id == 'eed598ff363d42658a095ae6c3ae1088'
     assert watson.frames[1].project == 'bar'
-    assert watson.frames[1].start.timestamp == 4010
-    assert watson.frames[1].stop.timestamp == 4015
+    assert watson.frames[1].start.int_timestamp == 4010
+    assert watson.frames[1].stop.int_timestamp == 4015
     assert watson.frames[1].tags == ['baz']
-    # assert watson.frames[1].updated_at.timestamp == 9000
-    assert watson.frames[1].updated_at.timestamp > 4035
+    # assert watson.frames[1].updated_at.int_timestamp == 9000
+    assert watson.frames[1].updated_at.int_timestamp > 4035
 
 # add
 

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -81,7 +81,7 @@ class DateTimeParamType(click.ParamType):
             # When we parse a date, we want to parse it in the timezone
             # expected by the user, so that midnight is midnight in the local
             # timezone, not in UTC. Cf issue #16.
-            date.tzinfo = tz.tzlocal()
+            date.replace(tzinfo=tz.tzlocal())
             # Add an offset to match the week beginning specified in the
             # configuration
             if param.name == "week":

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -81,7 +81,7 @@ class DateTimeParamType(click.ParamType):
             # When we parse a date, we want to parse it in the timezone
             # expected by the user, so that midnight is midnight in the local
             # timezone, not in UTC. Cf issue #16.
-            date.replace(tzinfo=tz.tzlocal())
+            date = date.replace(tzinfo=tz.tzlocal())
             # Add an offset to match the week beginning specified in the
             # configuration
             if param.name == "week":

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -35,9 +35,9 @@ class Frame(namedtuple('Frame', HEADERS)):
         )
 
     def dump(self):
-        start = self.start.to('utc').timestamp
-        stop = self.stop.to('utc').timestamp
-        updated_at = self.updated_at.timestamp
+        start = self.start.to('utc').int_timestamp
+        stop = self.stop.to('utc').int_timestamp
+        updated_at = self.updated_at.int_timestamp
 
         return (start, stop, self.project, self.id, self.tags, updated_at)
 

--- a/watson/fullmoon.py
+++ b/watson/fullmoon.py
@@ -222,7 +222,7 @@ def get_last_full_moon(d):
     Raises ValueError if the d value is not between 2000 - 2099
     """
 
-    now = d.timestamp
+    now = d.int_timestamp
     idx = bisect.bisect_right(fullmoons, now)
     if idx in [0, len(fullmoons)]:
         raise ValueError(

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -101,7 +101,7 @@ class Watson(object):
         if not isinstance(date, arrow.Arrow):
             date = arrow.get(date)
 
-        return date.timestamp
+        return date.int_timestamp
 
     @property
     def config(self):


### PR DESCRIPTION
The arrow library moved to 1.0.0 on February 24, 2021 and with it came breaking changes.
This pull request addresses those changes per the [arrow migration guide](https://github.com/arrow-py/arrow/issues/832).
