### PR TITLE
issue #391: Watson now supports setting the TZ env variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `log` command output can now be filtered to exclude projects and tags via `--ignore-project` and `--ignore-tag` (#395)
 - Python 3.8 support (#402)
 - Python 3.9 support (#402)
+- Support for the TZ environment variable to specify the local time zone (#391)
 
 ### Changed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,10 @@ import arrow
 from itertools import combinations
 from datetime import datetime, timedelta
 
-from dateutil.tz import tzlocal
 import pytest
 
 from watson import cli
+from watson.cli import local_tz_info
 
 
 # Not all ISO-8601 compliant strings are recognized by arrow.get(str)
@@ -173,7 +173,7 @@ def test_report_invalid_date(runner, watson, test_dt):
 @pytest.mark.parametrize('at_dt', VALID_TIMES_DATA)
 def test_stop_valid_time(runner, watson, mocker, at_dt):
     mocker.patch('arrow.arrow.dt_datetime', wraps=datetime)
-    start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=tzlocal())
+    start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=local_tz_info())
     arrow.arrow.dt_datetime.now.return_value = start_dt
     result = runner.invoke(cli.start, ['a-project'], obj=watson)
     assert result.exit_code == 0
@@ -190,7 +190,7 @@ def test_stop_valid_time(runner, watson, mocker, at_dt):
 def test_start_valid_time(runner, watson, mocker, at_dt):
     # Simulate a start date so that 'at_dt' is older than now().
     mocker.patch('arrow.arrow.dt_datetime', wraps=datetime)
-    start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=tzlocal())
+    start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=local_tz_info())
     arrow.arrow.dt_datetime.now.return_value = (start_dt + timedelta(hours=1))
     result = runner.invoke(cli.start, ['a-project', '--at', at_dt], obj=watson)
     assert result.exit_code == 0


### PR DESCRIPTION
Watson did not have a way to set the timezone, other than what the system used.
In unix  you can set the TZ variable to represent the timezone you want your
programs to respect.  I have updated watson to respect the TZ variable.
