### PR TITLE
Add gap/no-gap options to restart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The restart command now accepts the `--gap/--no-gap` options.
+
 ## [2.0.1] - 2021-05-10
 
 ### Fixed

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -608,12 +608,16 @@ Example:
     Stopping project apollo11, started a minute ago. (id: e7ccd52)
     $ watson restart
     Starting project apollo11 [module, brakes] at 16:36
+    
+If the `--no-gap` flag is given, the start time of the new project is set
+to the stop time of the most recently stopped project.
 
 ### Options
 
 Flag | Help
 -----|-----
 `--at DATETIME` | Start frame at this time. Must be in (YYYY-MM-DDT)?HH:MM(:SS)? format.
+`-g, --gap / -G, --no-gap` | (Don't) leave gap between end time of previous project and start time of the current.
 `-s, --stop / -S, --no-stop` | (Don't) Stop an already running project.
 `--help` | Show this message and exit.
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -579,7 +579,7 @@ Flag | Help
 ## `restart`
 
 ```bash
-Usage:  watson restart [OPTIONS] [FRAME]
+Usage:  watson restart [OPTIONS] [ID]
 ```
 
 Restart monitoring time for a previously stopped project.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,3 +194,21 @@ def test_start_valid_time(runner, watson, mocker, at_dt):
     arrow.arrow.dt_datetime.now.return_value = (start_dt + timedelta(hours=1))
     result = runner.invoke(cli.start, ['a-project', '--at', at_dt], obj=watson)
     assert result.exit_code == 0
+
+
+# watson restart
+
+@pytest.mark.parametrize('at_dt', VALID_TIMES_DATA)
+def test_restart_valid_time(runner, watson, mocker, at_dt):
+    # Create a previous entry the same as in `test_stop_valid_time`
+    mocker.patch('arrow.arrow.dt_datetime', wraps=datetime)
+    start_dt = datetime(2019, 4, 10, 14, 0, 0, tzinfo=local_tz_info())
+    arrow.arrow.dt_datetime.now.return_value = start_dt
+    result = runner.invoke(cli.start, ['a-project'], obj=watson)
+    # Simulate one hour has elapsed, so that 'at_dt' is older than now()
+    # but newer than the start date.
+    arrow.arrow.dt_datetime.now.return_value = (start_dt + timedelta(hours=1))
+    result = runner.invoke(cli.stop, ['--at', at_dt], obj=watson)
+    # Test that the last frame can be restarted
+    result = runner.invoke(cli.restart, ['--at', at_dt], obj=watson)
+    assert result.exit_code == 0

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -321,11 +321,11 @@ def stop(watson, at_):
                     "and start time of the current."))
 @click.option('-s/-S', '--stop/--no-stop', 'stop_', default=None,
               help="(Don't) Stop an already running project.")
-@click.argument('frame', default='-1', autocompletion=get_frames)
+@click.argument('id', default='-1', autocompletion=get_frames)
 @click.pass_obj
 @click.pass_context
 @catch_watson_error
-def restart(ctx, watson, frame, stop_, at_, gap_=True):
+def restart(ctx, watson, id, stop_, at_, gap_=True):
     """
     Restart monitoring time for a previously stopped project.
 
@@ -384,7 +384,7 @@ def restart(ctx, watson, frame, stop_, at_, gap_=True):
                 style('project', watson.current['project']),
                 style('tags', watson.current['tags'])))
 
-    frame = get_frame_from_argument(watson, frame)
+    frame = get_frame_from_argument(watson, id)
 
     _start(watson, frame.project, frame.tags, restart=True, start_at=at_,
            gap=gap_)


### PR DESCRIPTION
I often find myself typing in `watson restart -2 -G` or similar and being surprised when it doesn't work. Overall,  I think `restart` should work as similarly as possible to `start`, so I suggest adding the gap options in this PR. 

I also added a generic test for `restart` that can keep track of whether its basic functionality break in future PRs, although it doesn't test the gap options per se (same as for the start test).

I also changed the parameter name from `frame` to `id` to make `restart` consistent with `remove` and `edit`. Since you can pass a frame either by position or id, this param name is not ideal, but neither is `frame` since that is used as a variable name for an actual frame object. This is the smallest  change that brings consistency across commands.