### PR TITLE
Feat: add a --compact flag to the status command

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -692,6 +692,7 @@ Example:
 
 Flag | Help
 -----|-----
+`-c, --compact` | only output project and time elapsed in a compact format
 `-p, --project` | only output project
 `-t, --tags` | only show tags
 `-e, --elapsed` | only show time elapsed

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -407,6 +407,8 @@ def cancel(watson):
 
 
 @cli.command()
+@click.option('-c', '--compact', is_flag=True,
+              help="only output project and time elapsed in a compact format")
 @click.option('-p', '--project', is_flag=True,
               help="only output project")
 @click.option('-t', '--tags', is_flag=True,
@@ -415,7 +417,7 @@ def cancel(watson):
               help="only show time elapsed")
 @click.pass_obj
 @catch_watson_error
-def status(watson, project, tags, elapsed):
+def status(watson, compact, project, tags, elapsed):
     """
     Display when the current project was started and the time spent since.
 
@@ -456,6 +458,16 @@ def status(watson, project, tags, elapsed):
     if elapsed:
         click.echo("{}".format(
             style('time', current['start'].humanize())
+        ))
+        return
+
+    if compact:
+        elapsedtime = (current['start']).humanize(only_distance=True,
+                                                  granularity="minute")
+        elapsedtime = elapsedtime.split()[0] + "m"
+        click.echo("{} {}".format(
+            style('project', current['project']),
+            style('time', elapsedtime)
         ))
         return
 


### PR DESCRIPTION
> Related project scope: `cli`

## Description

In order to use watson output with tools like [starship](https://starship.rs/), this PR add a compact flag (`-c` or `--compact`) to the `status` command.

**Usage:**:
```
> watson status (-c | --compact)
<project> <time_elapsed_in_minutes>m
```

**Screenshot:**

![Screenshot from 2021-07-17 18-09-07](https://user-images.githubusercontent.com/44124798/126043040-2890361a-029b-49f7-89db-b39ac6691cb3.png)

## Changelog

### Features

* **cli:** add a --compact flag for the status command ([a16fa48](https://github.com/EmileRolley/Watson/commit/a16fa4800947fb6e72f9235129f5357516b2f5fe))