### PR TITLE
feat: add percentage for reporting

### DIFF
--- a/watson/utils.py
+++ b/watson/utils.py
@@ -68,7 +68,8 @@ def style(name, element):
         'error': {'fg': 'red'},
         'date': {'fg': 'cyan'},
         'short_id': _style_short_id,
-        'id': {'fg': 'white'}
+        'id': {'fg': 'white'},
+        'percentage': {'fg': 'magenta'}
     }
 
     fmt = formats.get(name, {})


### PR DESCRIPTION
Implementing a flag to display percentage with following logic:
- project percentages are calculated based on the whole time tracked with Watson.
- tag percentages refer to the time spent on the individual project

Fixes: #314 