### PR TITLE
Support for night owls: starting a day at later hour, e.g. 6, to properly report late night work

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -234,6 +234,7 @@ stop_on_restart = false
 date_format = %Y.%m.%d
 time_format = %H:%M:%S%z
 week_start = monday
+day_start_hour = 0
 log_current = false
 pager = true
 report_current = false

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -1067,7 +1067,8 @@ def log(watson, current, reverse, from_, to, projects, tags, ignore_projects,
     if reverse is None:
         reverse = watson.config.getboolean('options', 'reverse_log', True)
 
-    span = watson.frames.span(from_, to)
+    day_start_hour = watson.config.getint('options', 'day_start_hour', 0)
+    span = watson.frames.span(from_, to, day_start_hour)
     filtered_frames = watson.frames.filter(
         projects=projects or None, tags=tags or None,
         ignore_projects=ignore_projects or None,

--- a/watson/frames.py
+++ b/watson/frames.py
@@ -61,10 +61,10 @@ class Frame(namedtuple('Frame', HEADERS)):
 
 
 class Span(object):
-    def __init__(self, start, stop, timeframe='day'):
-        self.timeframe = timeframe
-        self.start = start.floor(self.timeframe)
-        self.stop = stop.ceil(self.timeframe)
+    def __init__(self, start, stop, shift_hours):
+        timeframe = 'day'
+        self.start = start.floor(timeframe).shift(hours=shift_hours)
+        self.stop = stop.ceil(timeframe).shift(hours=shift_hours)
 
     def overlaps(self, frame):
         return frame.start <= self.stop and frame.stop >= self.start
@@ -183,5 +183,5 @@ class Frames(object):
                 stop = span.stop if frame.stop > span.stop else frame.stop
                 yield frame._replace(start=start, stop=stop)
 
-    def span(self, start, stop):
-        return Span(start, stop)
+    def span(self, start, stop, shift_hours):
+        return Span(start, stop, shift_hours)

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -483,7 +483,8 @@ class Watson(object):
             self.frames.add(cur['project'], cur['start'], arrow.utcnow(),
                             cur['tags'], id="current")
 
-        span = self.frames.span(from_, to)
+        day_start_hour = self.config.getint('options', 'day_start_hour', 0)
+        span = self.frames.span(from_, to, day_start_hour)
 
         frames_by_project = sorted_groupby(
             self.frames.filter(


### PR DESCRIPTION
I like to work late at night, even after midnight. Using Watson in such a setting means reports will count part of my work as being done on the next day, while it was done on the same day from my perspective. I've added 'day_start_hour' option to shift time spans used for reports/aggregates to account for me working late.