### PR TITLE
Fix click 8 compatibility issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.0.0
-click>=7.0,<8.0
+click>=8.0
 click-didyoumean
 colorama; sys_platform == "win32"
 requests

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -204,7 +204,7 @@ def _start(watson, project, tags, restart=False, start_at=None, gap=True):
               help=("(Don't) leave gap between end time of previous project "
                     "and start time of the current."))
 @click.argument('args', nargs=-1,
-                autocompletion=get_project_or_task_completion)
+                shell_complete=get_project_or_task_completion)
 @click.option('-c', '--confirm-new-project', is_flag=True, default=False,
               help="Confirm addition of new project.")
 @click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
@@ -321,7 +321,7 @@ def stop(watson, at_):
                     "and start time of the current."))
 @click.option('-s/-S', '--stop/--no-stop', 'stop_', default=None,
               help="(Don't) Stop an already running project.")
-@click.argument('id', default='-1', autocompletion=get_frames)
+@click.argument('id', default='-1', shell_complete=get_frames)
 @click.pass_obj
 @click.pass_context
 @catch_watson_error
@@ -513,11 +513,11 @@ _SHORTCUT_OPTIONS_VALUES = {
               flag_value=_SHORTCUT_OPTIONS_VALUES['all'],
               mutually_exclusive=['day', 'week', 'month', 'luna', 'year'],
               help='Reports all activities.')
-@click.option('-p', '--project', 'projects', autocompletion=get_projects,
+@click.option('-p', '--project', 'projects', shell_complete=get_projects,
               multiple=True,
               help="Reports activity only for the given project. You can add "
               "other projects by using this option several times.")
-@click.option('-T', '--tag', 'tags', autocompletion=get_tags, multiple=True,
+@click.option('-T', '--tag', 'tags', shell_complete=get_tags, multiple=True,
               help="Reports activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
@@ -531,15 +531,13 @@ _SHORTCUT_OPTIONS_VALUES = {
               "given tag will be ignored")
 @click.option('-j', '--json', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='json', mutually_exclusive=['csv'],
-              multiple=True,
               help="Format output in JSON instead of plain text")
 @click.option('-s', '--csv', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='csv', mutually_exclusive=['json'],
-              multiple=True,
               help="Format output in CSV instead of plain text")
 @click.option('--plain', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='plain', mutually_exclusive=['json', 'csv'],
-              multiple=True, default=True, hidden=True,
+              default=True, hidden=True,
               help="Format output in plain text (default)")
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
@@ -776,25 +774,23 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
               mutually_exclusive=_SHORTCUT_OPTIONS,
               help="The date at which the report should stop (inclusive). "
               "Defaults to tomorrow.")
-@click.option('-p', '--project', 'projects', autocompletion=get_projects,
+@click.option('-p', '--project', 'projects', shell_complete=get_projects,
               multiple=True,
               help="Reports activity only for the given project. You can add "
               "other projects by using this option several times.")
-@click.option('-T', '--tag', 'tags', autocompletion=get_tags, multiple=True,
+@click.option('-T', '--tag', 'tags', shell_complete=get_tags, multiple=True,
               help="Reports activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
 @click.option('-j', '--json', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='json', mutually_exclusive=['csv'],
-              multiple=True,
               help="Format output in JSON instead of plain text")
 @click.option('-s', '--csv', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='csv', mutually_exclusive=['json'],
-              multiple=True,
               help="Format output in CSV instead of plain text")
 @click.option('--plain', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='plain', mutually_exclusive=['json', 'csv'],
-              multiple=True, default=True, hidden=True,
+              default=True, hidden=True,
               help="Format output in plain text (default)")
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
@@ -944,11 +940,11 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
               flag_value=_SHORTCUT_OPTIONS_VALUES['all'],
               mutually_exclusive=['day', 'week', 'month', 'year'],
               help='Reports all activities.')
-@click.option('-p', '--project', 'projects', autocompletion=get_projects,
+@click.option('-p', '--project', 'projects', shell_complete=get_projects,
               multiple=True,
               help="Logs activity only for the given project. You can add "
               "other projects by using this option several times.")
-@click.option('-T', '--tag', 'tags', autocompletion=get_tags, multiple=True,
+@click.option('-T', '--tag', 'tags', shell_complete=get_tags, multiple=True,
               help="Logs activity only for frames containing the given "
               "tag. You can add several tags by using this option multiple "
               "times")
@@ -962,15 +958,13 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
               "given tag will be ignored")
 @click.option('-j', '--json', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='json', mutually_exclusive=['csv'],
-              multiple=True,
               help="Format output in JSON instead of plain text")
 @click.option('-s', '--csv', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='csv', mutually_exclusive=['json'],
-              multiple=True,
               help="Format output in CSV instead of plain text")
 @click.option('--plain', 'output_format', cls=MutuallyExclusiveOption,
               flag_value='plain', mutually_exclusive=['json', 'csv'],
-              multiple=True, default=True, hidden=True,
+              default=True, hidden=True,
               help="Format output in plain text (default)")
 @click.option('-g/-G', '--pager/--no-pager', 'pager', default=None,
               help="(Don't) view output through a pager.")
@@ -1212,7 +1206,7 @@ def frames(watson):
 
 @cli.command(context_settings={'ignore_unknown_options': True})
 @click.argument('args', nargs=-1,
-                autocompletion=get_project_or_task_completion)
+                shell_complete=get_project_or_task_completion)
 @click.option('-f', '--from', 'from_', required=True, type=DateTime,
               help="Date and time of start of tracked activity")
 @click.option('-t', '--to', required=True, type=DateTime,
@@ -1272,7 +1266,7 @@ def add(watson, args, from_, to, confirm_new_project, confirm_new_tag):
               help="Confirm addition of new project.")
 @click.option('-b', '--confirm-new-tag', is_flag=True, default=False,
               help="Confirm creation of new tag.")
-@click.argument('id', required=False, autocompletion=get_frames)
+@click.argument('id', required=False, shell_complete=get_frames)
 @click.pass_obj
 @catch_watson_error
 def edit(watson, confirm_new_project, confirm_new_tag, id):
@@ -1401,7 +1395,7 @@ def edit(watson, confirm_new_project, confirm_new_tag, id):
 
 
 @cli.command(context_settings={'ignore_unknown_options': True})
-@click.argument('id', autocompletion=get_frames)
+@click.argument('id', shell_complete=get_frames)
 @click.option('-f', '--force', is_flag=True,
               help="Don't ask for confirmation.")
 @click.pass_obj
@@ -1695,9 +1689,9 @@ def merge(watson, frames_with_conflict, force):
 
 @cli.command()
 @click.argument('rename_type', required=True, metavar='TYPE',
-                autocompletion=get_rename_types)
-@click.argument('old_name', required=True, autocompletion=get_rename_name)
-@click.argument('new_name', required=True, autocompletion=get_rename_name)
+                shell_complete=get_rename_types)
+@click.argument('old_name', required=True, shell_complete=get_rename_name)
+@click.argument('new_name', required=True, shell_complete=get_rename_name)
 @click.pass_obj
 @catch_watson_error
 def rename(watson, rename_type, old_name, new_name):


### PR DESCRIPTION
- Fix multiple=True option
- Use click’s new parameter name of ‘shell_complete’

Rebase of #432 to prepare a new release!