### PR TITLE
Bump release to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2022-05-16
+
 ### Added
 
 - The restart command now accepts the `--gap/--no-gap` options.
+
+### Fixed
+
+- Watson is now compatible with Click 8+
 
 ## [2.0.1] - 2021-05-10
 
@@ -283,7 +289,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 First stable public release 🎉
 
-[unreleased]: https://github.com/tailordev/watson/compare/2.0.1...HEAD
+[unreleased]: https://github.com/tailordev/watson/compare/2.1.0...HEAD
+[2.1.0]: https://github.com/tailordev/watson/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/tailordev/watson/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/tailordev/watson/compare/1.10.0...2.0.0
 [1.10.0]: https://github.com/tailordev/watson/compare/1.9.0...1.10.0

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2022-05-16
+
+### Added
+
+- The restart command now accepts the `--gap/--no-gap` options.
+
+### Fixed
+
+- Watson is now compatible with Click 8+
+
 ## [2.0.1] - 2021-05-10
 
 ### Fixed
@@ -276,6 +286,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 First stable public release 🎉
 
+[2.1.0]: https://github.com/tailordev/watson/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/tailordev/watson/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/tailordev/watson/compare/1.10.0...2.0.0
 [1.10.0]: https://github.com/tailordev/watson/compare/1.9.0...1.10.0

--- a/watson.zsh-completion
+++ b/watson.zsh-completion
@@ -1,8 +1,11 @@
 #compdef watson
+
 _watson_completion() {
     local -a completions
     local -a completions_with_descriptions
     local -a response
+    (( ! $+commands[watson] )) && return 1
+
     response=("${(@f)$( env COMP_WORDS="${words[*]}" \
                         COMP_CWORD=$((CURRENT-1)) \
                         _WATSON_COMPLETE="complete_zsh" \
@@ -17,13 +20,13 @@ _watson_completion() {
     done
 
     if [ -n "$completions_with_descriptions" ]; then
-        _describe -V unsorted completions_with_descriptions -U -Q
+        _describe -V unsorted completions_with_descriptions -U
     fi
 
     if [ -n "$completions" ]; then
-        compadd -U -V unsorted -Q -a completions
+        compadd -U -V unsorted -a completions
     fi
     compstate[insert]="automenu"
 }
 
-_watson_completion
+compdef _watson_completion watson;

--- a/watson/version.py
+++ b/watson/version.py
@@ -1,1 +1,1 @@
-version = "2.0.1"
+version = "2.1.0"


### PR DESCRIPTION
### Added

- The restart command now accepts the `--gap/--no-gap` options.

### Fixed

- Watson is now compatible with Click 8+
