### PR TITLE
Add support for relative dates using dateparser

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -43,7 +43,8 @@ Else, print the total for each root project.
 
 By default, the time spent the last 7 days is printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
-must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+should have the format `YEAR-MONTH-DAY`, like: `2014-05-19`, but relative
+formats like `two weeks ago` are also supported.
 
 You can limit the report to a project or a tag using the `--project` and
 `--tag` options. They can be specified several times each to add multiple
@@ -234,7 +235,8 @@ Display each recorded session during the given timespan.
 
 By default, the sessions from the last 7 days are printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
-must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+should have the format `YEAR-MONTH-DAY`, like: `2014-05-19`, but relative
+formats like `two weeks ago` are also supported.
 
 You can also use special shortcut options for easier timespan control:
 `--day` sets the log timespan to the current day (beginning at `00:00h`)
@@ -457,7 +459,8 @@ Else, print the total for each root project.
 
 By default, the time spent the last 7 days is printed. This timespan
 can be controlled with the `--from` and `--to` arguments. The dates
-must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+should have the format `YEAR-MONTH-DAY`, like: `2014-05-19`, but relative
+formats like `two weeks ago` are also supported.
 
 You can also use special shortcut options for easier timespan control:
 `--day` sets the report timespan to the current day (beginning at `00:00h`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ arrow>=1.0.0
 click>=8.0
 click-didyoumean
 colorama; sys_platform == "win32"
+dateparser
 requests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,8 @@ from watson.cli import local_tz_info
 # Not all ISO-8601 compliant strings are recognized by arrow.get(str)
 VALID_DATES_DATA = [
     ('2018', '2018-01-01 00:00:00'),  # years
+    (' 2018', '2018-01-01 00:00:00'),
+    ('2018 ', '2018-01-01 00:00:00'),
     ('2018-04', '2018-04-01 00:00:00'),  # calendar dates
     ('2018-04-10', '2018-04-10 00:00:00'),
     ('2018/04/10', '2018-04-10 00:00:00'),
@@ -20,9 +22,12 @@ VALID_DATES_DATA = [
     ('2018/4/10', '2018-04-10 00:00:00'),
     ('2018.4.10', '2018-04-10 00:00:00'),
     ('20180410', '2018-04-10 00:00:00'),
+    ('18-04-10', '2018-04-10 00:00:00'),
+    ('2018-04-10T', '2018-04-10 00:00:00'),
     ('2018-123', '2018-05-03 00:00:00'),  # ordinal dates
     ('2018-04-10 12:30:43', '2018-04-10 12:30:43'),
     ('2018-04-10T12:30:43', '2018-04-10 12:30:43'),
+    ('2018-04-10T12:30:43.', '2018-04-10 12:30:43'),
     ('2018-04-10 12:30:43Z', '2018-04-10 12:30:43'),
     ('2018-04-10 12:30:43.1233', '2018-04-10 12:30:43'),
     ('2018-04-10 12:30:43+03:00', '2018-04-10 12:30:43'),
@@ -44,27 +49,50 @@ VALID_DATES_DATA = [
         .replace(hour=14, minute=5, second=0)
         .format('YYYY-MM-DD HH:mm:ss')
     ),
+    (
+        '14:05:12.000',
+        arrow.now()
+        .replace(hour=14, minute=5, second=12, microsecond=0)
+        .format('YYYY-MM-DD HH:mm:ss')
+    ),
+    (
+        '14.05',
+        arrow.now()
+        .replace(hour=14, minute=5, second=0)
+        .format('YYYY-MM-DD HH:mm:ss')
+    ),
+
     ('2018-W08', '2018-02-19 00:00:00'),  # week dates
     ('2018W08', '2018-02-19 00:00:00'),
     ('2018-W08-2', '2018-02-20 00:00:00'),
     ('2018W082', '2018-02-20 00:00:00'),
+    ('yesterday 9am',
+        arrow.now()
+        .shift(days=-1)
+        .replace(hour=9, minute=0, second=0)
+        .format('YYYY-MM-DD HH:mm:ss')
+    ),
+    (
+        'tomorrow 9am',
+        arrow.now()
+        .shift(days=1)
+        .replace(hour=9, minute=0, second=0)
+        .format('YYYY-MM-DD HH:mm:ss')
+    ),
+    (
+        '1.5 hours ago',
+        arrow.now()
+        .shift(hours=-1.5)
+        .format('YYYY-MM-DD HH:mm:ss')
+    ),
 ]
 
 INVALID_DATES_DATA = [
-    (' 2018'),
-    ('2018 '),
     ('201804'),
-    ('18-04-10'),
     ('180410'),  # truncated representation not allowed
     ('hello 2018'),
-    ('yesterday'),
-    ('tomorrow'),
-    ('14:05:12.000'),  # Times alone are not allowed
     ('140512.000'),
     ('140512'),
-    ('14.05'),
-    ('2018-04-10T'),
-    ('2018-04-10T12:30:43.'),
 ]
 
 VALID_TIMES_DATA = [

--- a/watson/__init__.py
+++ b/watson/__init__.py
@@ -1,4 +1,11 @@
+import warnings
+
 from .watson import __version__  # noqa
 from .watson import Watson, WatsonError
 
 __all__ = ['Watson', 'WatsonError']
+
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -9,6 +9,7 @@ from functools import reduce, wraps
 import arrow
 import click
 from click_didyoumean import DYMGroup
+import dateparser
 
 import watson as _watson
 from .autocompletion import (
@@ -109,6 +110,8 @@ class DateTimeParamType(click.ParamType):
 
     def _parse_multiformat(self, value) -> arrow:
         date = None
+        if isinstance(value, str):
+            value = value.strip()
         for fmt in (None, 'HH:mm:ss', 'HH:mm'):
             try:
                 if fmt is None:
@@ -123,6 +126,10 @@ class DateTimeParamType(click.ParamType):
                 break
             except (ValueError, TypeError):
                 pass
+        if date is None:
+            date = dateparser.parse(value, settings={'DATE_ORDER': 'YMD'})
+            if date:
+                date = arrow.get(date)
         return date
 
 
@@ -555,7 +562,8 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
 
     By default, the time spent the last 7 days is printed. This timespan
     can be controlled with the `--from` and `--to` arguments. The dates
-    must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+    should have the format `YEAR-MONTH-DAY`, like: `2014-05-19`, but relative
+    formats like `two weeks ago` are also supported.
 
     You can also use special shortcut options for easier timespan control:
     `--day` sets the report timespan to the current day (beginning at `00:00h`)
@@ -808,7 +816,8 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
 
     By default, the time spent the last 7 days is printed. This timespan
     can be controlled with the `--from` and `--to` arguments. The dates
-    must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+    should have the format `YEAR-MONTH-DAY`, like: `2014-05-19`, but relative
+    formats like `two weeks ago` are also supported.
 
     You can limit the report to a project or a tag using the `--project` and
     `--tag` options. They can be specified several times each to add multiple
@@ -978,7 +987,8 @@ def log(watson, current, reverse, from_, to, projects, tags, ignore_projects,
 
     By default, the sessions from the last 7 days are printed. This timespan
     can be controlled with the `--from` and `--to` arguments. The dates
-    must have the format `YEAR-MONTH-DAY`, like: `2014-05-19`.
+    should have the format `YEAR-MONTH-DAY`, like: `2014-05-19`, but relative
+    formats like `two weeks ago` are also supported.
 
     You can also use special shortcut options for easier timespan control:
     `--day` sets the log timespan to the current day (beginning at `00:00h`)


### PR DESCRIPTION
Hello! I appreciate this is a long-standing community discussion, and this PR may not be super helpful, but I implemented it to scratch my own itch and thought I'd offer it up.

Following the discussion in #10 there was a proposal to move to using `dateparser` for formatting dates. This isn't a perfect library, it currently makes some silly mistakes like parsing "1.5 hours ago" as "5 hours ago" and can be somewhat slow for confusing formats, but for all other day-to-day requirements I personally have, it handles them well.

This changes the `DateTime` parameter value to fall back on `dateparser` for any dates previously not allowable. This means that all currently acceptable dates are parsed in the same way, but some previously invalid dates are now allowable. 

There's also an issue at #475 for relative dates specifically, which is implemented by PR #481. That implements a subset of the parsing directly using arrow, which I understand may well be preferable. I'm under no illusions that 1 hour of hacking is anything special, but wanted to share rather than hide it away.