### PR TITLE
Adding formats to configuration, closes #94

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -217,6 +217,23 @@ Or in the configuration file:
 voyager2 = nasa 'space mission'
 ```
 
+### Formats
+
+The formats for the
+[`click.style`](https://click.palletsprojects.com/en/latest/api/#click.style)
+function that is used by Watson to report various kind of information can be
+configured in this section.
+
+Available names for formats are: `project`, `tag`, `time`, `error`, `date`, and
+`id` (used for frames ids). An example of configuration is
+
+```ini
+[formats]
+project = fg magenta reverse true
+time = fg bright_green
+id = fg red blink true reverse true
+```
+
 ## Sample configuration file
 
 A basic configuration file looks like the following:

--- a/watson/utils.py
+++ b/watson/utils.py
@@ -48,17 +48,17 @@ def confirm_tags(tags, watson_tags):
     return True
 
 
-def style(name, element):
+def style(name, element, config = None):
     def _style_tags(tags):
         if not tags:
             return ''
 
         return '[{}]'.format(', '.join(
-            style('tag', tag) for tag in tags
+            style('tag', tag, config) for tag in tags
         ))
 
     def _style_short_id(id):
-        return style('id', id[:7])
+        return style('id', id[:7], config)
 
     formats = {
         'project': {'fg': 'magenta'},
@@ -70,8 +70,12 @@ def style(name, element):
         'short_id': _style_short_id,
         'id': {'fg': 'white'}
     }
-
+    
     fmt = formats.get(name, {})
+    
+    if config: # if a configuration is available, we try to get there the format
+      lst = config.getlist('formats', name)
+      if lst and len(lst) % 2 == 0: fmt = dict(zip(lst[::2], lst[1::2]))
 
     if isinstance(fmt, dict):
         return click.style(element, **fmt)

--- a/watson/watson.py
+++ b/watson/watson.py
@@ -10,7 +10,7 @@ import click
 
 from .config import ConfigParser
 from .frames import Frames
-from .utils import deduplicate, make_json_writer, safe_save, sorted_groupby
+from .utils import deduplicate, make_json_writer, safe_save, sorted_groupby, style
 from .version import version as __version__  # noqa
 
 
@@ -581,3 +581,9 @@ class Watson(object):
 
         self.frames.changed = True
         self.save()
+    
+    def style(self = None, name = 'error', element = None):
+      if isinstance(self, Watson):
+        return style(name, element, self.config)
+      else:
+        return style(self, name)


### PR DESCRIPTION
This PR adds a `formats` configuration section that can contain configuration for colors (and other) used by click.style.