### PR TITLE
remove py36; add py310,py311

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Office/Business",
         "Topic :: Utilities",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py35,py36,py37,py38,py39
+envlist = flake8,py37,py38,py39,py310,py311
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py37,py38,py39,py310,py311
+envlist = flake8,py35,py36,py37,py38,py39,py310,py311
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
I am using Python 3.11 and I was curious if there are issues with it. I changed tox.ini and ran tox and it succeeded with 3.11 and 3.10