### PR TITLE
fix(docs): tiny fix to linux bash completion path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ $ pip install -e .
 #### Bash
 
 
-If you use a Bash-compatible shell, you can install the `watson.completion` file from the source distribution as `/etc/bash.completion.d/watson` - or wherever your distribution keeps the Bash completion configuration files. After you restart your shell, you can then just type `watson` on your command line and then hit `TAB` to see all available commands. Depending on your input, it completes `watson` commands, command options, projects, tags and frame IDs.
+If you use a Bash-compatible shell, you can install the `watson.completion` file from the source distribution as `/etc/bash_completion.d/watson` - or wherever your distribution keeps the Bash completion configuration files. After you restart your shell, you can then just type `watson` on your command line and then hit `TAB` to see all available commands. Depending on your input, it completes `watson` commands, command options, projects, tags and frame IDs.
 
 #### ZSH
 


### PR DESCRIPTION
Tiny fix to linux bash completion path