### PR TITLE
Fixed project listing missing projects defined in config

### DIFF
--- a/watson/watson.py
+++ b/watson/watson.py
@@ -316,7 +316,10 @@ class Watson(object):
         """
         Return the list of all the existing projects, sorted by name.
         """
-        return sorted(set(self.frames['project']))
+        projects = set(self.frames['project'])
+        if 'default_tags' in self.config.sections():
+            projects |= set(p[0] for p in self.config.items('default_tags'))
+        return sorted(projects)
 
     @property
     def tags(self):


### PR DESCRIPTION
My workflow includes using `default_tags` on projects to specify the code that should be used when sending my timesheet to the upstream system. That means that when starting new work, the first thing I do is adding the project to the `default_tags` section.

The problem is that `watson projects` does only print projects that already have frames registered.

This PR adds any projects listed in the `default_tags` section of the config to the `watson projects` output.